### PR TITLE
Fix npm README display and GitHub package linking

### DIFF
--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -1,0 +1,28 @@
+# @ash-ai/bridge
+
+Bridge process for [Ash](https://github.com/ash-ai-org/ash-ai) — runs inside each sandbox and communicates with the Claude Agent SDK.
+
+The bridge is the boundary between the isolated sandbox environment and the AI model. It receives messages over a Unix socket, forwards them to the Claude Agent SDK, and streams responses back.
+
+## Installation
+
+```bash
+npm install @ash-ai/bridge
+```
+
+## How it works
+
+```
+ash-server → Unix socket → bridge process → Claude Agent SDK
+                          (inside sandbox)
+```
+
+The bridge runs as an isolated child process with restricted environment variables, resource limits, and filesystem isolation.
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -5,14 +5,15 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/bridge"
   },
   "license": "MIT",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,47 @@
+# @ash-ai/cli
+
+CLI for deploying and managing [Ash](https://github.com/ash-ai-org/ash-ai) AI agents.
+
+## Installation
+
+```bash
+npm install -g @ash-ai/cli
+```
+
+## Usage
+
+```bash
+# Start the Ash server
+ash start
+
+# Deploy an agent from a folder
+ash deploy ./my-agent --name my-agent
+
+# Create a session and send messages
+ash session create my-agent
+ash session send <SESSION_ID> "Hello!"
+
+# List agents and sessions
+ash agent list
+ash session list
+```
+
+## What is an agent?
+
+An agent is a folder. The only required file is `CLAUDE.md`:
+
+```
+my-agent/
+├── CLAUDE.md              # System prompt (required)
+├── .claude/
+│   └── settings.json      # Permissions
+└── .mcp.json              # MCP server connections
+```
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,14 +8,15 @@
     "ash": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/cli"
   },
   "license": "MIT",

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,0 +1,28 @@
+# @ash-ai/runner
+
+[Ash](https://github.com/ash-ai-org/ash-ai) runner process — manages sandboxes on a worker node and exposes them over HTTP for the coordinator server.
+
+Used in multi-machine deployments where the Ash server acts as a control plane and runners host the actual sandboxes.
+
+## Installation
+
+```bash
+npm install @ash-ai/runner
+```
+
+## How it works
+
+```
+ash-server (coordinator)  ──HTTP──>  runner node 1  ──>  sandboxes
+                          ──HTTP──>  runner node 2  ──>  sandboxes
+```
+
+Runners register with the server, send heartbeats, and accept sandbox assignments. Sessions route to the least-loaded runner.
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -5,14 +5,15 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/runner"
   },
   "license": "MIT",

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,27 @@
+# @ash-ai/sandbox
+
+Sandbox management library for [Ash](https://github.com/ash-ai-org/ash-ai) — process spawning, pool management, bridge client, resource limits, and state persistence.
+
+Used by both `@ash-ai/server` and `@ash-ai/runner` to manage isolated agent sandboxes.
+
+## Installation
+
+```bash
+npm install @ash-ai/sandbox
+```
+
+## What's included
+
+- **SandboxManager** — spawns and manages isolated child processes
+- **SandboxPool** — DB-backed pool with capacity limits, LRU eviction, and idle sweep
+- **BridgeClient** — communicates with bridge processes over Unix sockets
+- **Resource limits** — cgroups (Linux) and ulimit enforcement
+- **State persistence** — save/restore sandbox state for session resume
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -11,14 +11,15 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/sandbox"
   },
   "license": "MIT",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,38 @@
+# @ash-ai/sdk
+
+TypeScript SDK for interacting with [Ash](https://github.com/ash-ai-org/ash-ai) agent servers.
+
+## Installation
+
+```bash
+npm install @ash-ai/sdk
+```
+
+## Usage
+
+```typescript
+import { AshClient } from '@ash-ai/sdk';
+
+const client = new AshClient({ serverUrl: 'http://localhost:4100' });
+
+// Create a session
+const session = await client.createSession('my-agent');
+
+// Stream messages
+for await (const event of client.sendMessageStream(session.id, 'Hello!')) {
+  if (event.type === 'message') {
+    process.stdout.write(event.data);
+  }
+}
+
+// End session
+await client.endSession(session.id);
+```
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation, including the [Python SDK](https://pypi.org/project/ash-ai/).
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,14 +11,15 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/sdk"
   },
   "license": "MIT",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,34 @@
+# @ash-ai/server
+
+The [Ash](https://github.com/ash-ai-org/ash-ai) agent orchestration server — Fastify REST API with SSE streaming, session management, agent registry, and sandbox orchestration.
+
+## Installation
+
+```bash
+npm install @ash-ai/server
+```
+
+## What's included
+
+- **REST API** — create sessions, send messages, manage agents
+- **SSE streaming** — real-time message streaming with backpressure
+- **Session management** — lifecycle, persistence (SQLite/Postgres), pause/resume
+- **Agent registry** — deploy agent folders, manage configurations
+- **Sandbox orchestration** — pool management, routing, resource limits
+
+## Quick start
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+npx @ash-ai/server
+```
+
+The server starts on port 4100 with Swagger UI at `/docs`.
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,14 +5,15 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/server"
   },
   "license": "MIT",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,25 @@
+# @ash-ai/shared
+
+Shared types, protocol definitions, and constants for the [Ash](https://github.com/ash-ai-org/ash-ai) agent orchestration system.
+
+This is an internal package used by `@ash-ai/server`, `@ash-ai/sandbox`, `@ash-ai/bridge`, `@ash-ai/cli`, and `@ash-ai/sdk`.
+
+## Installation
+
+```bash
+npm install @ash-ai/shared
+```
+
+## What's included
+
+- TypeScript type definitions for sessions, agents, messages, and sandbox state
+- Protocol constants for bridge communication (Unix socket, newline-delimited JSON)
+- Shared enums and error codes
+
+## Documentation
+
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation.
+
+## License
+
+[MIT](https://github.com/ash-ai-org/ash-ai/blob/main/LICENSE)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,14 +11,15 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ash-ai/ash.git",
+    "url": "https://github.com/ash-ai-org/ash-ai.git",
     "directory": "packages/shared"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fix `repository.url` in all 7 package.json files: `github.com/ash-ai/ash.git` → `github.com/ash-ai-org/ash-ai.git` (GitHub uses this field to link npm packages to the repository)
- Add `README.md` to each package directory with package-specific docs
- Add `README.md` to the `files` field so it ships with the npm tarball

## Test plan
- [ ] Verify npm package pages show README after next publish
- [ ] Verify GitHub repo shows linked packages under "Packages" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)