### PR TITLE
Fix Docker image pull from ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,3 +49,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Set package visibility to public
+        if: github.event_name == 'push'
+        run: gh api orgs/ash-ai-org/packages/container/ash/versions --jq '.[0].id' > /dev/null 2>&1 && gh api --method PUT orgs/ash-ai-org/packages/container/ash -f visibility=public || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:20-slim
 
+LABEL org.opencontainers.image.source=https://github.com/ash-ai-org/ash-ai
+LABEL org.opencontainers.image.description="Ash server — deploy and orchestrate hosted AI agents"
+LABEL org.opencontainers.image.licenses=MIT
+
 # bubblewrap for sandbox isolation, procps for ps/kill utilities
 RUN apt-get update && \
     apt-get install -y --no-install-recommends bubblewrap procps && \


### PR DESCRIPTION
## Summary
- Add OCI labels to Dockerfile so ghcr.io links the package to the repo (inherits public visibility)
- Add workflow step to explicitly set package visibility to public after push
- Fixes `unauthorized` error when running `ash start`

## Test plan
- [ ] Merge to main triggers docker.yml workflow
- [ ] After workflow completes, `docker pull ghcr.io/ash-ai-org/ash:0.0.3` works without auth
- [ ] `ash start` pulls and starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)