### PR TITLE
Build multi-platform Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -44,6 +46,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add QEMU setup for cross-platform emulation
- Build Docker image for both `linux/amd64` and `linux/arm64`
- Fixes `no matching manifest for linux/arm64/v8` error on Apple Silicon Macs

## Test plan
- [ ] Workflow builds successfully for both platforms
- [ ] `docker pull ghcr.io/ash-ai-org/ash:latest` works on Apple Silicon Mac
- [ ] `ash start` pulls and runs on Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)