### PR TITLE
Fix PyPI publish failing on unchanged versions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,3 +29,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/sdk-python/dist/
+          skip-existing: true


### PR DESCRIPTION
## Summary
- Add `skip-existing: true` to the `publish-pypi` workflow so it gracefully no-ops when the Python SDK version hasn't been bumped
- Previously, every push to main would attempt to upload the current `sdk-python` version to PyPI, failing with HTTP 400 when the version already existed

## Test plan
- [ ] Merge to main and verify the PyPI publish step succeeds (or skips) without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)