### PR TITLE
Fix PyPI publish failing on unchanged versions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,3 +29,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/sdk-python/dist/
+          skip-existing: true


### PR DESCRIPTION
The publish-pypi workflow runs on every push to main but would fail with HTTP 400 when the sdk-python version hadn't been bumped. Add skip-existing to gracefully no-op when the version is already on PyPI.