### PR TITLE
Add Helm chart for enterprise Kubernetes self-hosting

### DIFF
--- a/charts/ash/Chart.yaml
+++ b/charts/ash/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: ash
+description: Deploy and orchestrate hosted AI agents — self-hostable server with sandbox isolation
+type: application
+version: 0.1.0
+appVersion: "0.0.8"
+home: https://github.com/ash-ai-org/ash-ai
+sources:
+  - https://github.com/ash-ai-org/ash-ai
+keywords:
+  - ai
+  - agents
+  - claude
+  - orchestration
+  - sandbox
+maintainers:
+  - name: ash-ai-org
+    url: https://github.com/ash-ai-org

--- a/charts/ash/templates/NOTES.txt
+++ b/charts/ash/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Ash has been deployed.
+
+1. Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ash.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  kubectl get --namespace {{ .Release.Namespace }} svc {{ include "ash.fullname" . }} -w
+{{- else }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "ash.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+2. Check server health:
+  curl http://localhost:{{ .Values.service.port }}/health
+
+3. View Prometheus metrics:
+  curl http://localhost:{{ .Values.service.port }}/metrics
+
+{{- if not .Values.auth.apiKey }}
+{{- if not .Values.auth.existingSecret }}
+
+WARNING: No API key is configured. Ash endpoints are unprotected.
+Set auth.apiKey or auth.existingSecret for production use.
+{{- end }}
+{{- end }}

--- a/charts/ash/templates/_helpers.tpl
+++ b/charts/ash/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ash.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "ash.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ash.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "ash.labels" -}}
+helm.sh/chart: {{ include "ash.chart" . }}
+{{ include "ash.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "ash.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ash.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "ash.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ash.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name — either existing or generated.
+*/}}
+{{- define "ash.secretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- include "ash.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/ash/templates/configmap.yaml
+++ b/charts/ash/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+data:
+  ASH_PORT: {{ .Values.ash.port | quote }}
+  ASH_HOST: "0.0.0.0"
+  ASH_DATA_DIR: "/data"
+  ASH_MODE: {{ .Values.ash.mode | quote }}
+  ASH_MAX_SANDBOXES: {{ .Values.ash.maxSandboxes | quote }}
+  ASH_IDLE_TIMEOUT_MS: {{ .Values.ash.idleTimeoutMs | quote }}
+  {{- if .Values.ash.databaseUrl }}
+  ASH_DATABASE_URL: {{ .Values.ash.databaseUrl | quote }}
+  {{- end }}
+  {{- if .Values.ash.snapshotUrl }}
+  ASH_SNAPSHOT_URL: {{ .Values.ash.snapshotUrl | quote }}
+  {{- end }}
+  {{- if .Values.ash.s3Region }}
+  ASH_S3_REGION: {{ .Values.ash.s3Region | quote }}
+  {{- end }}

--- a/charts/ash/templates/hpa.yaml
+++ b/charts/ash/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "ash.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/ash/templates/ingress.yaml
+++ b/charts/ash/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ash.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ash/templates/pdb.yaml
+++ b/charts/ash/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ash.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ash/templates/secret.yaml
+++ b/charts/ash/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.auth.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.auth.anthropicApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.apiKey }}
+  ASH_API_KEY: {{ .Values.auth.apiKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/ash/templates/service-headless.yaml
+++ b/charts/ash/templates/service-headless.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ash.fullname" . }}-headless
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.ash.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ash.selectorLabels" . | nindent 4 }}

--- a/charts/ash/templates/service.yaml
+++ b/charts/ash/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "ash.selectorLabels" . | nindent 4 }}

--- a/charts/ash/templates/serviceaccount.yaml
+++ b/charts/ash/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ash.serviceAccountName" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ash/templates/servicemonitor.yaml
+++ b/charts/ash/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ash.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/ash/templates/statefulset.yaml
+++ b/charts/ash/templates/statefulset.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ash.fullname" . }}
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "ash.fullname" . }}-headless
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "ash.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ash.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ash.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ash.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ash.fullname" . }}
+            - secretRef:
+                name: {{ include "ash.secretName" . }}
+          {{- with .Values.ash.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 3"]
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/charts/ash/templates/tests/test-health.yaml
+++ b/charts/ash/templates/tests/test-health.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "ash.fullname" . }}-test-health
+  labels:
+    {{- include "ash.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: health-check
+      image: curlimages/curl:latest
+      command: ["curl", "-sf", "http://{{ include "ash.fullname" . }}:{{ .Values.service.port }}/health"]
+  restartPolicy: Never

--- a/charts/ash/values.yaml
+++ b/charts/ash/values.yaml
@@ -1,0 +1,261 @@
+# -- Number of Ash server replicas.
+# With SQLite (default), only 1 replica is supported.
+# With an external database (postgres/cockroachdb), you can scale to multiple replicas.
+replicaCount: 1
+
+image:
+  # -- Container image repository
+  repository: ghcr.io/ash-ai-org/ash
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag (default: Chart appVersion)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+# =============================================================================
+# Ash Server Configuration
+# =============================================================================
+
+ash:
+  # -- Server port (inside the container)
+  port: 4100
+
+  # -- Server mode: "standalone" (default) or "coordinator" (multi-runner)
+  mode: standalone
+
+  # -- Maximum number of concurrent sandboxes
+  maxSandboxes: 1000
+
+  # -- Idle session timeout in milliseconds (default: 30 minutes)
+  idleTimeoutMs: 1800000
+
+  # -- External database URL (postgres or cockroachdb).
+  # If empty, uses embedded SQLite (data stored on the persistent volume).
+  # Example: postgresql://user:pass@cockroachdb:26257/ash
+  databaseUrl: ""
+
+  # -- Cloud workspace persistence URL for cross-node session resume.
+  # Supports s3://bucket/prefix/ or gs://bucket/prefix/
+  snapshotUrl: ""
+
+  # -- S3 region override (default: us-east-1)
+  s3Region: ""
+
+  # -- Extra environment variables to set on the Ash container.
+  # Use this for any config not covered by the fields above.
+  # Example:
+  #   extraEnv:
+  #     - name: ASH_DEBUG_TIMING
+  #       value: "1"
+  extraEnv: []
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+auth:
+  # -- Ash API key for protecting endpoints.
+  # Set directly here, or use existingSecret below.
+  apiKey: ""
+
+  # -- Anthropic API key for Claude agent execution.
+  # Set directly here, or use existingSecret below.
+  anthropicApiKey: ""
+
+  # -- Use an existing Kubernetes Secret instead of creating one.
+  # The secret must contain the keys specified in existingSecretKeys.
+  existingSecret: ""
+
+  # -- Key names within the existing secret.
+  existingSecretKeys:
+    # -- Key in the secret containing the Ash API key
+    ashApiKey: ASH_API_KEY
+    # -- Key in the secret containing the Anthropic API key
+    anthropicApiKey: ANTHROPIC_API_KEY
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistent storage for SQLite database and session state
+  enabled: true
+  # -- Storage class (empty = cluster default)
+  storageClass: ""
+  # -- Access mode
+  accessMode: ReadWriteOnce
+  # -- Volume size
+  size: 10Gi
+  # -- Annotations for the PVC
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type: ClusterIP, NodePort, or LoadBalancer
+  type: ClusterIP
+  # -- Service port
+  port: 4100
+  # -- Node port (only used when type is NodePort)
+  nodePort: ""
+  # -- Additional service annotations (e.g. for service mesh, load balancer config)
+  annotations: {}
+  # -- Additional service labels
+  labels: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name (e.g. nginx, traefik, alb)
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: ash.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration
+  tls: []
+  #  - secretName: ash-tls
+  #    hosts:
+  #      - ash.example.com
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 4000m
+    memory: 8Gi
+
+# =============================================================================
+# Security
+# =============================================================================
+
+serviceAccount:
+  # -- Create a service account
+  create: true
+  # -- Service account annotations
+  annotations: {}
+  # -- Service account name (generated if not set)
+  name: ""
+
+# -- Pod-level security context.
+# Ash requires privileged mode for cgroup v2 sandbox resource limits.
+# If you don't need per-sandbox resource limits, you can disable privileged mode.
+podSecurityContext: {}
+
+securityContext:
+  # -- Privileged mode is required for cgroup v2 delegation (sandbox resource limits).
+  # Set to false if your cluster doesn't allow privileged containers —
+  # Ash will fall back to ulimit-based limits.
+  privileged: true
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 30
+
+# =============================================================================
+# Autoscaling (only useful with an external database, not SQLite)
+# =============================================================================
+
+autoscaling:
+  # -- Enable HPA. Only meaningful when using an external database
+  # (Postgres/CockroachDB), since SQLite limits you to 1 replica.
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# =============================================================================
+# Pod Disruption Budget
+# =============================================================================
+
+podDisruptionBudget:
+  # -- Enable PDB
+  enabled: false
+  # -- Minimum available pods
+  minAvailable: 1
+  # -- Maximum unavailable pods (alternative to minAvailable)
+  # maxUnavailable: 1
+
+# =============================================================================
+# Monitoring
+# =============================================================================
+
+metrics:
+  # -- Enable Prometheus ServiceMonitor (requires prometheus-operator CRDs)
+  serviceMonitor:
+    enabled: false
+    # -- Scrape interval
+    interval: 30s
+    # -- Additional labels for the ServiceMonitor (e.g. release: prometheus)
+    additionalLabels: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Topology spread constraints
+topologySpreadConstraints: []

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@
 | [guides/ec2-deployment.md](./guides/ec2-deployment.md) | Deploy Ash to EC2 (example scripts in `examples/deploy/ec2/`) |
 | [guides/gce-deployment.md](./guides/gce-deployment.md) | Deploy Ash to GCP Compute Engine (example scripts in `examples/deploy/gce/`) |
 | [guides/backend-for-frontend.md](./guides/backend-for-frontend.md) | Why and how to put a BFF between your browser app and Ash |
+| [guides/kubernetes-deployment.md](./guides/kubernetes-deployment.md) | Deploy Ash to Kubernetes with the official Helm chart (`charts/ash/`) |
 
 ## Plan
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,6 +232,21 @@ ash start --database-url "postgresql://localhost:5432/ash"
 
 Ash auto-creates its tables on first startup. No migrations needed.
 
+### Option E: Kubernetes (Helm Chart)
+
+Deploy Ash to any Kubernetes cluster with the official Helm chart:
+
+```bash
+kubectl create secret generic ash-secrets \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+  --from-literal=ASH_API_KEY=$(openssl rand -hex 32)
+
+helm install ash ./charts/ash \
+  --set auth.existingSecret=ash-secrets
+```
+
+See the full [Kubernetes Deployment Guide](guides/kubernetes-deployment.md) for production configuration, external database setup, and enterprise integration.
+
 ## Next Steps
 
 - [Connecting to a Server](guides/connecting.md) — use the SDK, CLI, Python, or curl against any Ash server
@@ -240,3 +255,4 @@ Ash auto-creates its tables on first startup. No migrations needed.
 - [Architecture](architecture.md) — how the pieces fit together
 - [Deploy to EC2](guides/ec2-deployment.md) — run your own server on AWS
 - [Deploy to GCE](guides/gce-deployment.md) — run your own server on GCP
+- [Deploy to Kubernetes](guides/kubernetes-deployment.md) — Helm chart for enterprise self-hosting

--- a/docs/guides/kubernetes-deployment.md
+++ b/docs/guides/kubernetes-deployment.md
@@ -1,0 +1,228 @@
+# Kubernetes Deployment
+
+Deploy Ash to any Kubernetes cluster using the official Helm chart.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.x
+- An Anthropic API key
+
+## Quick Start
+
+```bash
+# Add your API key to a Kubernetes secret
+kubectl create secret generic ash-secrets \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+  --from-literal=ASH_API_KEY=$(openssl rand -hex 32)
+
+# Install the chart
+helm install ash ./charts/ash \
+  --set auth.existingSecret=ash-secrets
+```
+
+Ash is now running at `http://ash:4100` inside the cluster.
+
+## Configuration
+
+All configuration is in `values.yaml`. Override values with `--set` or `-f your-values.yaml`.
+
+### Minimal Production Values
+
+```yaml
+# production.yaml
+replicaCount: 1
+
+auth:
+  existingSecret: ash-secrets    # pre-created K8s secret with API keys
+
+persistence:
+  size: 50Gi
+
+resources:
+  requests:
+    cpu: 1000m
+    memory: 4Gi
+  limits:
+    cpu: 4000m
+    memory: 16Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: ash.internal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: ash-tls
+      hosts:
+        - ash.internal.example.com
+```
+
+```bash
+helm install ash ./charts/ash -f production.yaml
+```
+
+### With External Database (CockroachDB/Postgres)
+
+For multi-replica deployments, use an external database instead of SQLite:
+
+```yaml
+# production-ha.yaml
+replicaCount: 3
+
+ash:
+  databaseUrl: "postgresql://ash@cockroachdb:26257/ash?sslmode=verify-full"
+
+auth:
+  existingSecret: ash-secrets
+
+persistence:
+  size: 20Gi          # less needed since state is in the database
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
+### Enterprise Integration
+
+The chart exposes standard integration points:
+
+| Integration | How |
+|-------------|-----|
+| **Service mesh** (Consul, Istio) | `service.annotations` |
+| **Service dashboard** | `service.labels`, `podLabels` |
+| **Internal registry** | `image.repository` pointed at your ECR/GCR mirror |
+| **Prometheus** | `metrics.serviceMonitor.enabled: true` |
+| **Ingress controller** | `ingress.enabled: true` with your `className` |
+| **Node placement** | `nodeSelector`, `tolerations`, `affinity` |
+| **Secrets manager** | `auth.existingSecret` referencing an external-secrets-synced Secret |
+
+Example with Consul service sync and internal registry:
+
+```yaml
+image:
+  repository: 123456789.dkr.ecr.us-west-2.amazonaws.com/ash-ai/ash
+  tag: "0.0.8"
+
+service:
+  annotations:
+    consul.hashicorp.com/service-name: ash-agents
+    consul.hashicorp.com/service-sync: "true"
+  labels:
+    my-dashboard/enabled: "true"
+    my-dashboard/name: ash-agents
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus
+```
+
+## Image Mirroring
+
+For air-gapped or policy-restricted clusters, mirror the image to your internal registry:
+
+```bash
+# Pull from GHCR
+docker pull ghcr.io/ash-ai-org/ash:0.0.8
+
+# Tag for your registry
+docker tag ghcr.io/ash-ai-org/ash:0.0.8 \
+  YOUR_REGISTRY/ash-ai/ash:0.0.8
+
+# Push
+docker push YOUR_REGISTRY/ash-ai/ash:0.0.8
+```
+
+Then set `image.repository` in your values.
+
+## Security
+
+### Privileged Mode
+
+The Ash container runs privileged by default to enable cgroup v2 delegation for per-sandbox resource limits. If your cluster policy disallows privileged containers:
+
+```yaml
+securityContext:
+  privileged: false
+```
+
+Ash will fall back to ulimit-based resource limits for sandboxes.
+
+### API Key Authentication
+
+Always set an API key in production. Three options:
+
+1. **Existing secret** (recommended): Create the secret externally (e.g., via external-secrets-operator or sealed-secrets), reference it with `auth.existingSecret`.
+
+2. **Inline** (development only): Set `auth.apiKey` and `auth.anthropicApiKey` directly in values. Not recommended for production since values files may be committed to source control.
+
+3. **No auth** (local dev): Omit both. Ash will warn but run without authentication.
+
+## Monitoring
+
+### Health Checks
+
+- **`GET /health`** — JSON status with active sessions, sandbox count, pool stats
+- **`GET /metrics`** — Prometheus text format with `ash_up`, `ash_active_sessions`, `ash_pool_sandboxes`, resume counters
+
+### ServiceMonitor
+
+If you run prometheus-operator, enable the ServiceMonitor:
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus    # match your Prometheus selector
+```
+
+### Helm Test
+
+Verify the deployment:
+
+```bash
+helm test ash
+```
+
+This runs a pod that curls the `/health` endpoint.
+
+## Persistence
+
+By default, Ash uses embedded SQLite stored on a persistent volume at `/data`. This volume holds:
+
+- SQLite database (session state, agent registry, message history)
+- Sandbox working directories (agent code, session files)
+
+Size the volume based on expected concurrent sessions and retention. 10Gi is fine for development; 50-100Gi for production.
+
+## Upgrading
+
+```bash
+helm upgrade ash ./charts/ash -f production.yaml
+```
+
+The StatefulSet performs a rolling update. The `preStop` hook ensures graceful shutdown with a 3-second drain period. Active sessions will be paused and can be resumed on the new pod.
+
+## Uninstalling
+
+```bash
+helm uninstall ash
+```
+
+Note: PersistentVolumeClaims created by the StatefulSet are **not** deleted automatically. To delete data:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=ash
+```


### PR DESCRIPTION
Official Helm chart at charts/ash/ that lets enterprises deploy Ash to
any Kubernetes cluster with ~30 lines of values config. Follows the
Qdrant pattern: ship a production-quality Helm chart + Docker image so
teams only write their infrastructure glue (service mesh, image
mirroring, GitOps config).

Chart includes: StatefulSet with volumeClaimTemplates for SQLite
persistence, headless service for DNS discovery, optional ingress,
ConfigMap/Secret for configuration, ServiceAccount, PDB, HPA (for
external DB mode), Prometheus ServiceMonitor, and a Helm test hook.

Supports three auth modes: disabled (dev), inline values (simple),
existing Kubernetes Secret (enterprise). External database
(Postgres/CockroachDB) enables multi-replica scaling with HPA.