### PR TITLE
release: v0.0.9

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.8 - 2026-02-25
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.9
+
 ## 0.0.7 - 2026-02-24
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ash-ai/cli
 
+## 0.0.8 - 2026-02-25
+
+### Added
+
+- Auto-capture API key from bootstrap file after `ash start` — saved to `~/.ash/config.json` (#23)
+- `--api-key` option on `ash connect` for remote server authentication (#23)
+- `getApiKey()` config function with precedence: `ASH_API_KEY` env > `config.json` (#23)
+- `api_key` field in `~/.ash/config.json` (#23)
+
+### Changed
+
+- All CLI HTTP requests now send `Authorization: Bearer` header when a key is available (#23)
+- Updated dependencies: @ash-ai/shared@0.0.9
+
 ## 0.0.7 - 2026-02-24
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.5 - 2026-02-25
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.4 - 2026-02-24
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.8 - 2026-02-25
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.9, @ash-ai/sandbox@0.0.8
+
 ## 0.0.7 - 2026-02-24
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.8 - 2026-02-25
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.9
+
 ## 0.0.7 - 2026-02-24
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.8 - 2026-02-25
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.7 - 2026-02-24
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.7"
+version = "0.0.8"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.9 - 2026-02-25
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.9
+
 ## 0.0.8 - 2026-02-25
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ash-ai/server
 
+## 0.0.9 - 2026-02-25
+
+### Added
+
+- Auto-generate `ash_`-prefixed API key on first server start when no keys exist (#23)
+- `generateApiKey()` helper in auth module (#23)
+- Bootstrap file (`{dataDir}/initial-api-key`) for CLI key pickup (#23)
+
+### Changed
+
+- Auth is now required when DB has keys, even without `ASH_API_KEY` env — removes dev-mode fallback (#23)
+- `registerAuth()` accepts `hasDbKeys` param to control auth enforcement (#23)
+- Updated dependencies: @ash-ai/shared@0.0.9
+
 ## 0.0.8 - 2026-02-25
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.9 - 2026-02-25
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.8 - 2026-02-25
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.4 - 2026-02-25
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.3 - 2026-02-24
 
 ### Added

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bumps and CHANGELOG updates for all packages.

## Packages

| Package | Version |
|---------|---------|
| @ash-ai/server | 0.0.8 → 0.0.9 |
| @ash-ai/cli | 0.0.7 → 0.0.8 |
| @ash-ai/sdk | 0.0.8 → 0.0.9 |
| @ash-ai/shared | 0.0.8 → 0.0.9 |
| @ash-ai/sandbox | 0.0.7 → 0.0.8 |
| @ash-ai/bridge | 0.0.7 → 0.0.8 |
| @ash-ai/runner | 0.0.7 → 0.0.8 |
| @ash-ai/mcp-server | 0.0.4 → 0.0.5 |
| @ash-ai/ui | 0.0.3 → 0.0.4 |
| ash-ai-sdk (PyPI) | 0.0.7 → 0.0.8 |

## Highlights

- **Auto-generated API keys**: Server generates `ash_`-prefixed key on first start, CLI captures it automatically (#23)
- Auth is now always on once keys exist (no more dev-mode fallback)

CI will create tags, GitHub releases, and publish to npm/PyPI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)