### PR TITLE
release: @ash-ai/server v0.0.10, @ash-ai/cli v0.0.9, @ash-ai/sdk v0.0.10, @ash-ai/shared v0.0.10, @ash-ai/sandbox v0.0.9, @ash-ai/bridge v0.0.9, @ash-ai/runner v0.0.9, @ash-ai/mcp-server v0.0.6, @ash-ai/ui v0.0.5, ash-ai-sdk v0.0.9

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.9 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10
+
 ## 0.0.8 - 2026-02-25
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.9 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10
+
 ## 0.0.8 - 2026-02-25
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.6 - 2026-02-26
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.5 - 2026-02-25
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.9 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10, @ash-ai/sandbox@0.0.9
+
 ## 0.0.8 - 2026-02-25
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/sandbox
 
+## 0.0.9 - 2026-02-26
+
+### Added
+
+- Per-sandbox home directory isolation: each sandbox gets a private writable `/home/ash-sandbox` via bind mount (#25)
+- Seed `.claude` config files from base image into per-sandbox home (#25)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10
+
 ## 0.0.8 - 2026-02-25
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.9 - 2026-02-26
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.8 - 2026-02-25
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.8"
+version = "0.0.9"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/sdk
 
+## 0.0.10 - 2026-02-26
+
+### Added
+
+- `createAgent()` method fields for agent creation via SDK (#25)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10
+
 ## 0.0.9 - 2026-02-25
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.10 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.10, @ash-ai/sandbox@0.0.9
+
 ## 0.0.9 - 2026-02-25
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.10 - 2026-02-26
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.9 - 2026-02-25
 
 ### Changed

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/ui
 
+## 0.0.5 - 2026-02-26
+
+### Fixed
+
+- Duplicate React key warning in Terminal log list (#25)
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.4 - 2026-02-25
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bumps and CHANGELOG updates for all packages.

### Key changes (from #25)
- Per-sandbox home directory isolation with bind mount over `/home/ash-sandbox`
- `createAgent()` SDK method fields
- Terminal duplicate React key fix
- Integration test auth and docs updates