### PR TITLE
Bridge ready signal, remove connect polling, fix UI streaming

### DIFF
--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -165,7 +165,8 @@ const server = net.createServer((conn) => {
 });
 
 server.listen(socketPath, () => {
-  // Bridge is ready — server will detect via 'ready' event on connect
+  // Signal readiness to parent — eliminates polling in BridgeClient.connect()
+  process.stdout.write('R');
 });
 
 // Graceful shutdown


### PR DESCRIPTION
## Summary
- Bridge writes `R` byte to stdout when socket is listening, eliminating the 100ms polling loop in `BridgeClient.connect()`
- `SandboxManager` waits for the ready signal before connecting — no more retry loop
- Fix playground chat duplicating content from `text_delta` events and final assembled message
- Only finalize streaming state when there's actual content

## Test plan
- [ ] Verify sandbox creation still works (bridge connects without polling)
- [ ] Verify playground chat doesn't show duplicated text
- [ ] Run unit tests: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)