### PR TITLE
release: v0.0.11

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/bridge
 
+## 0.0.10 - 2026-02-26
+
+### Added
+
+- Sidecar MCP server support: bridge spawns MCP servers defined in `.mcp.json` as child processes (#27)
+- Ready signal: bridge writes `R` byte to stdout when socket is listening, eliminating polling (#28)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11
+
 ## 0.0.9 - 2026-02-26
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.10 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11
+
 ## 0.0.9 - 2026-02-26
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.7 - 2026-02-26
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.6 - 2026-02-26
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/runner
 
+## 0.0.10 - 2026-02-26
+
+### Added
+
+- Forward `mcpServers` and `systemPrompt` from session creation to sandbox (#27)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11, @ash-ai/sandbox@0.0.10
+
 ## 0.0.9 - 2026-02-26
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @ash-ai/sandbox
 
+## 0.0.10 - 2026-02-26
+
+### Added
+
+- Per-session MCP servers: merge session-level `mcpServers` into agent's `.mcp.json` (#27)
+- Per-session system prompt override via `systemPrompt` option (#27)
+- Bridge ready signal wait: `SandboxManager` waits for `R` byte from bridge stdout before connecting (#28)
+
+### Fixed
+
+- Removed 100ms polling loop in `BridgeClient.connect()` — socket is guaranteed listening (#28)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11
+
 ## 0.0.9 - 2026-02-26
 
 ### Added

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.10 - 2026-02-26
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.9 - 2026-02-26
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.9"
+version = "0.0.10"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/sdk
 
+## 0.0.11 - 2026-02-26
+
+### Added
+
+- `mcpServers` and `systemPrompt` options on `createSession()` for per-session MCP and system prompt override (#27)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11
+
 ## 0.0.10 - 2026-02-26
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/server
 
+## 0.0.11 - 2026-02-26
+
+### Added
+
+- Forward `mcpServers` and `systemPrompt` from session creation to sandbox (#27)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.11, @ash-ai/sandbox@0.0.10
+
 ## 0.0.10 - 2026-02-26
 
 ### Changed

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ash-ai/shared
 
+## 0.0.11 - 2026-02-26
+
+### Added
+
+- `McpServerConfig` type for per-session MCP server configuration (#27)
+- `mcpServers` and `systemPrompt` fields on `CreateSessionRequest` (#27)
+- `BRIDGE_READY_TIMEOUT_MS` constant (#28)
+
 ## 0.0.10 - 2026-02-26
 
 ### Changed

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/ui
 
+## 0.0.6 - 2026-02-26
+
+### Fixed
+
+- Streaming content duplication: use final assembled message as authoritative content (#28)
+- Only finalize streaming state when there's actual content to display (#28)
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.5 - 2026-02-26
 
 ### Fixed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- Patch release for all packages
- Bridge ready signal + removed connect polling
- Per-session MCP servers and system prompt override
- UI streaming deduplication fix

## Versions
| Package | Version |
|---------|---------|
| @ash-ai/server | 0.0.11 |
| @ash-ai/shared | 0.0.11 |
| @ash-ai/sdk | 0.0.11 |
| @ash-ai/sandbox | 0.0.10 |
| @ash-ai/bridge | 0.0.10 |
| @ash-ai/runner | 0.0.10 |
| @ash-ai/cli | 0.0.10 |
| @ash-ai/mcp-server | 0.0.7 |
| @ash-ai/ui | 0.0.6 |
| ash-ai-sdk | 0.0.10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)