### PR TITLE
CLI improvements, ECS rolling deploy, and cloud-chat example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
        ec2-deploy ec2-teardown smoke-ec2 \
        ec2-deploy-distributed ec2-teardown-distributed smoke-distributed \
        gce-deploy gce-teardown smoke-gce \
+       ecs-deploy ecs-teardown deploy-runtime \
        changeset changeset-status version-packages publish publish-dry-run \
        openapi sdk-python
 
@@ -167,6 +168,20 @@ ec2-teardown-distributed:
 # Run smoke test against distributed EC2 deployment
 smoke-distributed:
 	./examples/deploy/ec2-distributed/smoke-test.sh
+
+# Deploy Ash to ECS Fargate (first-time setup, creates all infra)
+ecs-deploy:
+	./scripts/deploy-ecs.sh
+
+# Tear down ECS Fargate deployment
+ecs-teardown:
+	./scripts/teardown-ecs.sh
+
+# Zero-downtime rolling deploy of the Ash runtime on ECS
+# Usage: make deploy-runtime          (re-pull :latest)
+#        make deploy-runtime TAG=0.0.12  (pinned version)
+deploy-runtime:
+	./scripts/deploy-runtime.sh $(TAG)
 
 # Deploy Ash server to GCE (requires gcloud CLI authenticated)
 gce-deploy:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,7 @@
 | [guides/gce-deployment.md](./guides/gce-deployment.md) | Deploy Ash to GCP Compute Engine (example scripts in `examples/deploy/gce/`) |
 | [guides/backend-for-frontend.md](./guides/backend-for-frontend.md) | Why and how to put a BFF between your browser app and Ash |
 | [guides/kubernetes-deployment.md](./guides/kubernetes-deployment.md) | Deploy Ash to Kubernetes with the official Helm chart (`charts/ash/`) |
+| [guides/ecs-rolling-deploy.md](./guides/ecs-rolling-deploy.md) | Zero-downtime rolling deploys on ECS Fargate |
 
 ## Plan
 

--- a/docs/guides/ecs-rolling-deploy.md
+++ b/docs/guides/ecs-rolling-deploy.md
@@ -1,0 +1,85 @@
+# ECS Rolling Deploy
+
+Zero-downtime deployment for the Ash runtime on ECS Fargate.
+
+## How It Works
+
+The ECS service uses a rolling deployment strategy:
+
+1. ECS spins up a **new task** alongside the existing one (`maximum_percent = 200`)
+2. The NLB health check waits for the new task to pass `/health`
+3. Once healthy, ECS drains connections from the **old task**
+4. The old task is stopped — zero downtime
+
+A **deployment circuit breaker** is enabled: if the new task repeatedly fails health checks, ECS automatically rolls back to the previous task definition.
+
+## Deploy Latest
+
+Re-pull the `:latest` tag and force a new deployment:
+
+```bash
+make deploy-runtime
+# or
+./scripts/deploy-runtime.sh
+```
+
+This calls `aws ecs update-service --force-new-deployment`, which triggers a rolling replace even if the image tag hasn't changed (useful when `:latest` has been updated in the registry).
+
+## Deploy a Pinned Version
+
+Deploy a specific image tag:
+
+```bash
+make deploy-runtime TAG=0.0.12
+# or
+./scripts/deploy-runtime.sh 0.0.12
+```
+
+This creates a new ECS task definition revision pointing to `ghcr.io/ash-ai-org/ash:0.0.12`, then updates the service.
+
+## Rollback
+
+Deploy the previous version explicitly:
+
+```bash
+make deploy-runtime TAG=0.0.11
+```
+
+Or, if a deploy fails health checks, the circuit breaker auto-rolls back to the last working task definition. Check the AWS Console (ECS > Service > Deployments) or:
+
+```bash
+aws ecs describe-services --cluster ash --services ash-runtime \
+  --query 'services[0].deployments'
+```
+
+## Monitoring a Deploy
+
+The deploy script waits for the service to stabilize (`aws ecs wait services-stable`) and then verifies the `/health` endpoint. To monitor manually:
+
+```bash
+# Watch deployment status
+aws ecs describe-services --cluster ash --services ash-runtime \
+  --query 'services[0].{desired: desiredCount, running: runningCount, deployments: deployments[*].{status: status, running: runningCount, desired: desiredCount}}'
+
+# Tail logs
+aws logs tail /ash/runtime --follow --region us-east-1
+
+# Health check
+curl http://<nlb-dns>:4100/health
+```
+
+## Prerequisites
+
+- AWS CLI v2 configured
+- Terraform state from initial `deploy-ecs.sh`
+- `jq` installed (for pinned version deploys)
+
+## Configuration
+
+The rolling deploy settings are in `infra/ecs-fargate/ecs.tf`:
+
+| Setting | Value | Meaning |
+|---------|-------|---------|
+| `minimum_healthy_percent` | 100 | Never drop below desired_count during deploy |
+| `maximum_percent` | 200 | Allow 2x tasks during deploy (1 old + 1 new) |
+| Circuit breaker | enabled + rollback | Auto-rollback on repeated health check failures |

--- a/examples/cloud-chat/.env.example
+++ b/examples/cloud-chat/.env.example
@@ -1,0 +1,7 @@
+# Ash Cloud Platform
+# Sign up at https://ash-cloud-platform.vercel.app/ and create an API key
+# in Settings > API Keys. The key needs these scopes:
+#   - agents:read    (list available agents)
+#   - sessions:write (create sessions + send messages)
+ASH_CLOUD_URL=https://ash-cloud-platform.vercel.app
+ASH_CLOUD_API_KEY=ash_tel_your_key_here

--- a/examples/cloud-chat/README.md
+++ b/examples/cloud-chat/README.md
@@ -1,0 +1,57 @@
+# Cloud Chat
+
+Chat with AI agents hosted on the [Ash Cloud Platform](https://ash-cloud-platform.vercel.app/).
+
+Unlike the other examples (qa-bot, hosted-agent) which connect to a self-hosted Ash instance, this example connects to the cloud platform where agents are configured through the dashboard.
+
+## Prerequisites
+
+1. Sign up at [ash-cloud-platform.vercel.app](https://ash-cloud-platform.vercel.app/)
+2. Create at least one agent in the dashboard
+3. Create an API key in **Settings > API Keys** with scopes:
+   - `agents:read` — list available agents
+   - `sessions:write` — create sessions and send messages
+
+## Setup
+
+```bash
+cd examples/cloud-chat
+cp .env.example .env.local
+
+# Edit .env.local with your API key
+```
+
+## Run
+
+```bash
+npm install
+npm run dev
+# Open http://localhost:3200
+```
+
+## How it works
+
+```
+Browser  ──HTTP──>  Next.js API routes  ──HTTP──>  Ash Cloud Platform
+                    (keeps API key                  (manages agents,
+                     server-side)                    sandboxes, streaming)
+```
+
+1. **Agent picker** — fetches available agents from `GET /api/agents`
+2. **Session creation** — `POST /api/sessions` with `{ agentSlug }` (cloud platform field name)
+3. **Message streaming** — `POST /api/sessions/:id/messages` returns SSE with granular events:
+   - `text_delta` — incremental text tokens
+   - `thinking_delta` — model thinking (extended thinking)
+   - `tool_start` / `tool_end` — tool usage
+   - `turn_complete` — response finished
+   - `error` — something went wrong
+
+## Key difference from self-hosted examples
+
+| | Self-hosted (qa-bot) | Cloud (this example) |
+|---|---|---|
+| Agent setup | `deployAgent()` from local folder | Pre-configured in dashboard |
+| Session creation body | `{ agent: "name" }` | `{ agentSlug: "slug" }` |
+| SDK dependency | `@ash-ai/sdk` | Raw `fetch` (standalone) |
+| Server URL | `http://localhost:4100` | `https://ash-cloud-platform.vercel.app` |
+| API key source | `ash start` auto-generates | Dashboard > Settings > API Keys |

--- a/examples/cloud-chat/app/api/agents/route.ts
+++ b/examples/cloud-chat/app/api/agents/route.ts
@@ -1,0 +1,14 @@
+import { ashClient } from '@/lib/ash-cloud';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const agents = await ashClient.listAgents();
+    return NextResponse.json({ agents });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to list agents' },
+      { status: 500 },
+    );
+  }
+}

--- a/examples/cloud-chat/app/api/sessions/[id]/messages/route.ts
+++ b/examples/cloud-chat/app/api/sessions/[id]/messages/route.ts
@@ -1,0 +1,42 @@
+import { ashClient } from '@/lib/ash-cloud';
+import { NextRequest } from 'next/server';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { content } = (await req.json()) as { content: string };
+
+  if (!content) {
+    return new Response(JSON.stringify({ error: 'content is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const res = await ashClient.sendMessage(id, content, { includePartialMessages: true });
+
+    if (!res.body) {
+      return new Response(JSON.stringify({ error: 'No response body' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Pipe the SSE stream from the cloud platform through to the browser
+    return new Response(res.body, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  } catch (e) {
+    return new Response(
+      JSON.stringify({ error: e instanceof Error ? e.message : 'Failed to send message' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+}

--- a/examples/cloud-chat/app/api/sessions/route.ts
+++ b/examples/cloud-chat/app/api/sessions/route.ts
@@ -1,0 +1,32 @@
+import { ashClient } from '@/lib/ash-cloud';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  try {
+    const agent = req.nextUrl.searchParams.get('agent') || undefined;
+    const sessions = await ashClient.listSessions(agent ? { agent } : undefined);
+    return NextResponse.json({ sessions });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to list sessions' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const agent = body.agent || body.agentSlug;
+    if (!agent) {
+      return NextResponse.json({ error: 'agent is required' }, { status: 400 });
+    }
+    const session = await ashClient.createSession(agent);
+    return NextResponse.json({ session });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to create session' },
+      { status: 500 },
+    );
+  }
+}

--- a/examples/cloud-chat/app/globals.css
+++ b/examples/cloud-chat/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/examples/cloud-chat/app/layout.tsx
+++ b/examples/cloud-chat/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Cloud Chat — Ash',
+  description: 'Chat with AI agents on Ash Cloud Platform',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-zinc-950 text-zinc-100 antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/cloud-chat/app/page.tsx
+++ b/examples/cloud-chat/app/page.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { parseSSEStream, extractDisplayItems, extractStreamDelta } from '@ash-ai/sdk';
+import type { AshStreamEvent, DisplayItem, Agent } from '@ash-ai/sdk';
+
+// -- Types ------------------------------------------------------------------
+
+interface Message {
+  role: 'user' | 'assistant';
+  items: DisplayItem[];
+}
+
+// -- Component --------------------------------------------------------------
+
+export default function CloudChat() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState<string>('');
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Fetch agents on mount
+  const fetchAgents = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agents');
+      if (res.ok) {
+        const { agents: list } = await res.json();
+        setAgents(list);
+        if (list.length > 0 && !selectedAgent) {
+          // Use slug if available, fall back to name
+          setSelectedAgent(list[0].slug || list[0].name);
+        }
+      }
+    } catch {
+      setError('Failed to load agents. Check your API key.');
+    }
+  }, [selectedAgent]);
+
+  useEffect(() => {
+    fetchAgents();
+  }, [fetchAgents]);
+
+  async function createSession(): Promise<string> {
+    const res = await fetch('/api/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: selectedAgent }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || 'Failed to create session');
+    }
+    const { session } = await res.json();
+    setSessionId(session.id);
+    return session.id;
+  }
+
+  async function handleSend() {
+    const text = input.trim();
+    if (!text || isStreaming || !selectedAgent) return;
+
+    setInput('');
+    setError(null);
+    setMessages((prev) => [...prev, { role: 'user', items: [{ type: 'text', content: text }] }]);
+    setIsStreaming(true);
+
+    try {
+      const sid = sessionId ?? (await createSession());
+
+      const res = await fetch(`/api/sessions/${sid}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: text }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to send message');
+      }
+
+      if (!res.body) throw new Error('No response body');
+
+      setMessages((prev) => [...prev, { role: 'assistant', items: [] }]);
+
+      let streamingText = '';
+
+      for await (const event of parseSSEStream(res.body) as AsyncGenerator<AshStreamEvent>) {
+        if (event.type === 'message') {
+          // Check for incremental text delta (streaming tokens)
+          const delta = extractStreamDelta(event.data);
+          if (delta !== null) {
+            streamingText += delta;
+            const currentText = streamingText;
+            setMessages((prev) =>
+              prev.map((msg, i) =>
+                i === prev.length - 1 && msg.role === 'assistant'
+                  ? { ...msg, items: [{ type: 'text' as const, content: currentText }] }
+                  : msg,
+              ),
+            );
+            continue;
+          }
+
+          // Complete message -- replace streaming text with final items
+          const displayItems = extractDisplayItems(event.data);
+          if (displayItems) {
+            streamingText = '';
+            setMessages((prev) =>
+              prev.map((msg, i) =>
+                i === prev.length - 1 && msg.role === 'assistant'
+                  ? { ...msg, items: displayItems }
+                  : msg,
+              ),
+            );
+          }
+        } else if (event.type === 'error') {
+          const errData = event.data as Record<string, unknown>;
+          throw new Error((errData.error as string) || 'Stream error');
+        }
+      }
+
+      // If no text came through, show a fallback
+      if (!streamingText) {
+        setMessages((prev) =>
+          prev.map((msg, i) =>
+            i === prev.length - 1 && msg.role === 'assistant' && msg.items.length === 0
+              ? { ...msg, items: [{ type: 'text' as const, content: '[No response]' }] }
+              : msg,
+          ),
+        );
+      }
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : 'Unknown error';
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', items: [{ type: 'text' as const, content: `Error: ${errorMsg}` }] },
+      ]);
+    } finally {
+      setIsStreaming(false);
+    }
+  }
+
+  function handleNewSession() {
+    setSessionId(null);
+    setMessages([]);
+    setInput('');
+    setError(null);
+  }
+
+  return (
+    <div className="flex flex-col h-screen max-w-3xl mx-auto">
+      {/* Header */}
+      <header className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-semibold">Ash Cloud Chat</h1>
+          {sessionId && (
+            <span className="text-xs font-mono text-zinc-500">{sessionId.slice(0, 8)}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Agent picker */}
+          <select
+            value={selectedAgent}
+            onChange={(e) => {
+              setSelectedAgent(e.target.value);
+              handleNewSession();
+            }}
+            disabled={isStreaming}
+            className="rounded-md bg-zinc-800 border border-zinc-700 px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {agents.length === 0 && <option value="">Loading agents...</option>}
+            {agents.map((a) => (
+              <option key={a.slug || a.name} value={a.slug || a.name}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleNewSession}
+            disabled={isStreaming}
+            className="px-3 py-1.5 text-sm rounded-md bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 transition-colors"
+          >
+            New Session
+          </button>
+        </div>
+      </header>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-4 py-2 bg-red-900/30 border-b border-red-800 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
+        {messages.length === 0 && (
+          <div className="text-center text-zinc-500 mt-20 space-y-2">
+            <p>Send a message to start a conversation.</p>
+            {selectedAgent && (
+              <p className="text-xs text-zinc-600">
+                Agent: <span className="text-zinc-400">{selectedAgent}</span>
+              </p>
+            )}
+          </div>
+        )}
+        {messages.map((msg, i) => (
+          <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div className="max-w-[80%] space-y-2">
+              {msg.items.length === 0 && isStreaming && i === messages.length - 1 && (
+                <div className="rounded-lg px-4 py-2.5 bg-zinc-800 text-zinc-400 text-sm">
+                  Thinking...
+                </div>
+              )}
+              {msg.items.map((item, j) => {
+                if (item.type === 'text') {
+                  return (
+                    <div
+                      key={j}
+                      className={`rounded-lg px-4 py-2.5 whitespace-pre-wrap ${
+                        msg.role === 'user'
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-zinc-800 text-zinc-100'
+                      }`}
+                    >
+                      {item.content}
+                    </div>
+                  );
+                }
+                if (item.type === 'tool_use') {
+                  return (
+                    <div key={j} className="rounded-lg px-3 py-2 bg-zinc-900 border border-zinc-700 text-xs font-mono">
+                      <span className="text-amber-400">{item.toolName}</span>
+                      {item.toolInput && (
+                        <span className="text-zinc-400 ml-2">{item.toolInput}</span>
+                      )}
+                    </div>
+                  );
+                }
+                if (item.type === 'tool_result') {
+                  return (
+                    <pre key={j} className="rounded-lg px-3 py-2 bg-zinc-900 border border-zinc-700 text-xs font-mono text-zinc-300 overflow-x-auto max-h-48 overflow-y-auto">
+                      {item.content}
+                    </pre>
+                  );
+                }
+                return null;
+              })}
+            </div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-zinc-800 px-4 py-3">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSend();
+          }}
+          className="flex gap-2"
+        >
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={selectedAgent ? 'Type a message...' : 'Select an agent first...'}
+            disabled={isStreaming || !selectedAgent}
+            className="flex-1 rounded-md bg-zinc-800 border border-zinc-700 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            disabled={isStreaming || !input.trim() || !selectedAgent}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:hover:bg-blue-600 transition-colors"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/examples/cloud-chat/lib/ash-cloud.ts
+++ b/examples/cloud-chat/lib/ash-cloud.ts
@@ -1,0 +1,8 @@
+import { AshClient } from '@ash-ai/sdk';
+
+// Point at the cloud platform — same SDK, different URL.
+// Set ASH_CLOUD_URL in .env.local (defaults to production cloud platform)
+const serverUrl = (process.env.ASH_CLOUD_URL || 'https://ash-cloud-platform.vercel.app').replace(/\/$/, '');
+const apiKey = process.env.ASH_CLOUD_API_KEY || undefined;
+
+export const ashClient = new AshClient({ serverUrl, apiKey });

--- a/examples/cloud-chat/next-env.d.ts
+++ b/examples/cloud-chat/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/cloud-chat/next.config.ts
+++ b/examples/cloud-chat/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/cloud-chat/package.json
+++ b/examples/cloud-chat/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cloud-chat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3200",
+    "build": "next build",
+    "start": "next start --port 3200"
+  },
+  "dependencies": {
+    "@ash-ai/sdk": "workspace:*",
+    "@ash-ai/shared": "workspace:*",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/cloud-chat/postcss.config.mjs
+++ b/examples/cloud-chat/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/examples/cloud-chat/tsconfig.json
+++ b/examples/cloud-chat/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/infra/ecs-fargate/ecs.tf
+++ b/infra/ecs-fargate/ecs.tf
@@ -89,5 +89,15 @@ resource "aws_ecs_service" "ash" {
     container_port   = 4100
   }
 
+  deployment_configuration {
+    minimum_healthy_percent = 100
+    maximum_percent         = 200
+
+    deployment_circuit_breaker {
+      enable   = true
+      rollback = true
+    }
+  }
+
   depends_on = [aws_lb_listener.ash]
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -24,7 +24,7 @@ export function saveConfig(config: AshConfig): void {
 }
 
 export function getServerUrl(): string {
-  // Priority: env var > config file > default
+  // Priority: env var > config file > credentials file (from `ash login`) > default
   if (process.env.ASH_SERVER_URL) {
     return process.env.ASH_SERVER_URL;
   }
@@ -32,14 +32,32 @@ export function getServerUrl(): string {
   if (config.server_url) {
     return config.server_url;
   }
+  try {
+    const raw = readFileSync(join(homedir(), '.ash', 'credentials.json'), 'utf-8');
+    const creds = JSON.parse(raw) as { cloud_url?: string };
+    if (creds.cloud_url) {
+      return creds.cloud_url;
+    }
+  } catch {
+    // no credentials file
+  }
   return 'http://localhost:4100';
 }
 
 export function getApiKey(): string | undefined {
-  // Priority: env var > config file
+  // Priority: env var > config file > credentials file (from `ash login`)
   if (process.env.ASH_API_KEY) {
     return process.env.ASH_API_KEY;
   }
   const config = loadConfig();
-  return config.api_key;
+  if (config.api_key) {
+    return config.api_key;
+  }
+  try {
+    const raw = readFileSync(join(homedir(), '.ash', 'credentials.json'), 'utf-8');
+    const creds = JSON.parse(raw) as { api_key?: string };
+    return creds.api_key;
+  } catch {
+    return undefined;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,43 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/cloud-chat:
+    dependencies:
+      '@ash-ai/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@ash-ai/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      next:
+        specifier: ^15.0.0
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.2.0
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   examples/hosted-agent:
     dependencies:
       '@ash-ai/sdk':
@@ -228,7 +265,7 @@ importers:
         version: 8.5.6
       postcss-cli:
         specifier: ^11.0.0
-        version: 11.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)
+        version: 11.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -240,7 +277,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -7264,6 +7301,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:
@@ -16831,14 +16869,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-cli@11.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.3
       picocolors: 1.1.1
       postcss: 8.5.6
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-load-config: 5.1.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)
       postcss-reporter: 7.1.0(postcss@8.5.6)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
@@ -16987,12 +17025,12 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.6)
       postcss: 8.5.6
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-load-config@5.1.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 1.21.7
       postcss: 8.5.6
       tsx: 4.21.0
 
@@ -17001,15 +17039,6 @@ snapshots:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.6
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.21.0
       yaml: 2.8.2
@@ -18420,7 +18449,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -18431,7 +18460,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Zero-downtime deploy for the Ash ECS Fargate runtime service.
+#
+# Usage:
+#   ./scripts/deploy-runtime.sh          # Re-pull :latest, force new deployment
+#   ./scripts/deploy-runtime.sh 0.0.12   # Deploy a pinned image version
+#
+# Prerequisites:
+#   - AWS CLI v2 configured (aws sts get-caller-identity)
+#   - Existing ECS deployment (run deploy-ecs.sh first)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+TF_DIR="$ROOT/infra/ecs-fargate"
+VERSION="${1:-}"
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}==> $*${NC}"; }
+ok()    { echo -e "${GREEN}==> $*${NC}"; }
+warn()  { echo -e "${YELLOW}==> $*${NC}"; }
+fail()  { echo -e "${RED}==> ERROR: $*${NC}" >&2; exit 1; }
+
+# --- Check prerequisites ---
+command -v aws >/dev/null 2>&1 || fail "AWS CLI not found."
+command -v jq >/dev/null 2>&1 || fail "jq not found."
+aws sts get-caller-identity >/dev/null 2>&1 || fail "AWS credentials not configured."
+command -v terraform >/dev/null 2>&1 || fail "Terraform not found."
+
+# --- Get cluster/service info from Terraform outputs ---
+info "Reading deployment info from Terraform state..."
+
+CLUSTER=$(terraform -chdir="$TF_DIR" output -raw ecs_cluster_name 2>/dev/null) || fail "Could not read ecs_cluster_name. Is the ECS stack deployed?"
+SERVICE=$(terraform -chdir="$TF_DIR" output -raw ecs_service_name 2>/dev/null) || fail "Could not read ecs_service_name."
+ASH_URL=$(terraform -chdir="$TF_DIR" output -raw ash_url 2>/dev/null) || fail "Could not read ash_url."
+
+# Region — not a Terraform output, fall back to env var or default
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+echo "  Cluster: $CLUSTER"
+echo "  Service: $SERVICE"
+echo "  Region:  $REGION"
+echo ""
+
+# --- Get current task definition for reference ---
+CURRENT_TASK_DEF=$(aws ecs describe-services \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --region "$REGION" \
+  --query 'services[0].taskDefinition' \
+  --output text)
+CURRENT_IMAGE=$(aws ecs describe-task-definition \
+  --task-definition "$CURRENT_TASK_DEF" \
+  --region "$REGION" \
+  --query 'taskDefinition.containerDefinitions[0].image' \
+  --output text)
+
+info "Current image: $CURRENT_IMAGE"
+
+if [[ -z "$VERSION" ]]; then
+  # --- No version: force new deployment (re-pulls :latest) ---
+  info "Forcing new deployment (re-pull current image)..."
+  aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --region "$REGION" \
+    --force-new-deployment \
+    --query 'service.deployments[0].id' \
+    --output text
+else
+  # --- Version specified: update task definition with new image ---
+  NEW_IMAGE="ghcr.io/ash-ai-org/ash:${VERSION}"
+  info "Deploying version: $NEW_IMAGE"
+
+  # Get current task definition JSON
+  TASK_DEF_JSON=$(aws ecs describe-task-definition \
+    --task-definition "$CURRENT_TASK_DEF" \
+    --region "$REGION" \
+    --query 'taskDefinition')
+
+  # Create new task definition with updated image
+  NEW_TASK_DEF=$(echo "$TASK_DEF_JSON" | \
+    jq --arg img "$NEW_IMAGE" '
+      .containerDefinitions[0].image = $img |
+      {
+        family,
+        taskRoleArn,
+        executionRoleArn,
+        networkMode,
+        containerDefinitions,
+        requiresCompatibilities,
+        cpu,
+        memory
+      }
+    ' | \
+    aws ecs register-task-definition \
+      --region "$REGION" \
+      --cli-input-json file:///dev/stdin \
+      --query 'taskDefinition.taskDefinitionArn' \
+      --output text)
+
+  info "New task definition: $NEW_TASK_DEF"
+
+  # Update service to use new task definition
+  aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --region "$REGION" \
+    --task-definition "$NEW_TASK_DEF" \
+    --query 'service.deployments[0].id' \
+    --output text
+fi
+
+# --- Wait for deployment to stabilize ---
+info "Waiting for deployment to stabilize (this may take a few minutes)..."
+aws ecs wait services-stable \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --region "$REGION"
+
+# --- Verify health ---
+info "Verifying health endpoint..."
+HEALTH_OK=false
+for i in $(seq 1 6); do
+  if curl -sf "$ASH_URL/health" >/dev/null 2>&1; then
+    HEALTH_OK=true
+    break
+  fi
+  sleep 5
+done
+
+if [[ "$HEALTH_OK" == "true" ]]; then
+  ok "Health check passed!"
+else
+  warn "Health check did not pass. The service may still be starting."
+  warn "  Try: curl $ASH_URL/health"
+fi
+
+# --- Print summary ---
+NEW_TASK_DEF_AFTER=$(aws ecs describe-services \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --region "$REGION" \
+  --query 'services[0].taskDefinition' \
+  --output text)
+NEW_IMAGE_AFTER=$(aws ecs describe-task-definition \
+  --task-definition "$NEW_TASK_DEF_AFTER" \
+  --region "$REGION" \
+  --query 'taskDefinition.containerDefinitions[0].image' \
+  --output text)
+RUNNING_COUNT=$(aws ecs describe-services \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --region "$REGION" \
+  --query 'services[0].runningCount' \
+  --output text)
+
+echo ""
+echo "============================================"
+ok "Deployment complete"
+echo "============================================"
+echo ""
+echo "  Before: $CURRENT_IMAGE"
+echo "  After:  $NEW_IMAGE_AFTER"
+echo "  Running tasks: $RUNNING_COUNT"
+echo ""
+echo "  Health:  curl $ASH_URL/health"
+echo "  Logs:    aws logs tail /${CLUSTER}/runtime --follow --region $REGION"
+echo ""


### PR DESCRIPTION
## Summary
- Centralize HTTP error handling in CLI client — move per-function `!res.ok` checks into the shared `request()` helper
- Add paste-API-key fallback to `ash login` for headless/SSH environments where browser can't open
- CLI config now reads `~/.ash/credentials.json` (from `ash login`) as fallback for server URL and API key
- ECS Fargate: add deployment circuit breaker with auto-rollback and rolling deploy configuration
- New `scripts/deploy-runtime.sh` for zero-downtime ECS rolling deploys
- New `examples/cloud-chat/` — Next.js app demonstrating Ash Cloud SDK integration
- Docs: ECS rolling deploy guide

## Test plan
- [ ] `ash login` works with browser callback flow
- [ ] `ash login` works with paste-API-key fallback
- [ ] CLI commands pick up credentials from `~/.ash/credentials.json`
- [ ] `cloud-chat` example builds and runs locally
- [ ] ECS rolling deploy script handles tag parameter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)