### PR TITLE
release: @ash-ai/server v0.0.12, @ash-ai/cli v0.0.11, @ash-ai/sdk v0.0.12, @ash-ai/shared v0.0.12, @ash-ai/sandbox v0.0.11, @ash-ai/bridge v0.0.11, @ash-ai/runner v0.0.11, @ash-ai/mcp-server v0.0.8, @ash-ai/ui v0.0.7, ash-ai-sdk v0.0.11

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.11 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12
+
 ## 0.0.10 - 2026-02-26
 
 ### Added

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ash-ai/cli
 
+## 0.0.11 - 2026-02-26
+
+### Added
+
+- Paste-API-key fallback for `ash login` in headless/SSH environments (#30)
+- Read credentials from `~/.ash/credentials.json` as fallback for server URL and API key (#30)
+
+### Changed
+
+- Centralize HTTP error handling in CLI client `request()` function (#30)
+- Updated dependencies: @ash-ai/shared@0.0.12
+
 ## 0.0.10 - 2026-02-26
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.8 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12, @ash-ai/sdk@0.0.12
+
 ## 0.0.7 - 2026-02-26
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.11 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12, @ash-ai/sandbox@0.0.11
+
 ## 0.0.10 - 2026-02-26
 
 ### Added

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.11 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12
+
 ## 0.0.10 - 2026-02-26
 
 ### Added

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.11 - 2026-02-26
+
+### Changed
+
+- Patch version bump (no direct changes)
+
 ## 0.0.10 - 2026-02-26
 
 ### Changed

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.12 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12
+
 ## 0.0.11 - 2026-02-26
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.12 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12, @ash-ai/sandbox@0.0.11
+
 ## 0.0.11 - 2026-02-26
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.12 - 2026-02-26
+
+### Changed
+
+- Patch version bump (no direct changes)
+
 ## 0.0.11 - 2026-02-26
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.7 - 2026-02-26
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.12, @ash-ai/sdk@0.0.12
+
 ## 0.0.6 - 2026-02-26
 
 ### Fixed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release. The only package with real changes is `@ash-ai/cli`; all others are dependency bumps.

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/server | 0.0.11 | 0.0.12 |
| @ash-ai/cli | 0.0.10 | **0.0.11** |
| @ash-ai/sdk | 0.0.11 | 0.0.12 |
| @ash-ai/shared | 0.0.11 | 0.0.12 |
| @ash-ai/sandbox | 0.0.10 | 0.0.11 |
| @ash-ai/bridge | 0.0.10 | 0.0.11 |
| @ash-ai/runner | 0.0.10 | 0.0.11 |
| @ash-ai/mcp-server | 0.0.7 | 0.0.8 |
| @ash-ai/ui | 0.0.6 | 0.0.7 |
| ash-ai-sdk | 0.0.10 | 0.0.11 |

### @ash-ai/cli v0.0.11 highlights
- Centralize HTTP error handling in CLI client `request()` function
- Add paste-API-key fallback to `ash login` for headless/SSH environments
- Read credentials from `~/.ash/credentials.json` as config fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)