### PR TITLE
fix: persist server_url from login callback

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -12,6 +12,7 @@ export interface AshCredentials {
   api_key: string;
   cloud_url: string;
   email?: string;
+  server_url?: string;
 }
 
 export function getCredentials(): AshCredentials | null {
@@ -69,6 +70,7 @@ export function loginCommand(): Command {
 
           const apiKey = url.searchParams.get('api_key');
           const email = url.searchParams.get('email');
+          const serverUrl = url.searchParams.get('server_url');
           const error = url.searchParams.get('error');
 
           if (error) {
@@ -88,7 +90,7 @@ export function loginCommand(): Command {
             return;
           }
 
-          saveCredentials({ api_key: apiKey, cloud_url: cloudUrl, email });
+          saveCredentials({ api_key: apiKey, cloud_url: cloudUrl, email, server_url: serverUrl || undefined });
 
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.end(`<html><body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><div style="text-align:center"><h2>Logged in!</h2><p>You can close this tab and return to your terminal.</p></div></body></html>`);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,10 @@ export function getServerUrl(): string {
   }
   try {
     const raw = readFileSync(join(homedir(), '.ash', 'credentials.json'), 'utf-8');
-    const creds = JSON.parse(raw) as { cloud_url?: string };
+    const creds = JSON.parse(raw) as { server_url?: string; cloud_url?: string };
+    if (creds.server_url) {
+      return creds.server_url;
+    }
     if (creds.cloud_url) {
       return creds.cloud_url;
     }


### PR DESCRIPTION
## Summary
- Save `server_url` from the cloud auth callback into `~/.ash/credentials.json`
- Use `server_url` from credentials when resolving which server to talk to (before falling back to `cloud_url`)
- Add `server_url` field to `AshCredentials` interface

## Test plan
- [ ] Run `ash login`, verify `credentials.json` includes `server_url` when returned by cloud
- [ ] Verify `getServerUrl()` returns `server_url` from credentials when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)