### PR TITLE
release: @ash-ai/server v0.0.14, @ash-ai/cli v0.0.13, @ash-ai/sdk v0.0.14, @ash-ai/shared v0.0.14, @ash-ai/sandbox v0.0.13, @ash-ai/bridge v0.0.13, @ash-ai/runner v0.0.13, @ash-ai/mcp-server v0.0.10, @ash-ai/ui v0.0.9, ash-ai-sdk v0.0.12

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/bridge
 
+## 0.0.13 - 2026-02-27
+
+### Added
+
+- Configurable permission mode via `ASH_PERMISSION_MODE` env var (#34)
+- Support for `permissionsByAgent` mode to use SDK permission system with `.claude/settings.json` (#34)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14
+
 ## 0.0.12 - 2026-02-27
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.13 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14
+
 ## 0.0.12 - 2026-02-27
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.10 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14, @ash-ai/sdk@0.0.14
+
 ## 0.0.9 - 2026-02-27
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.13 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14, @ash-ai/sandbox@0.0.13
+
 ## 0.0.12 - 2026-02-27
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.13 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14
+
 ## 0.0.12 - 2026-02-27
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.12 - 2026-02-27
+
+### Changed
+
+- Patch version bump (no direct changes)
+
 ## 0.0.11 - 2026-02-27
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.11"
+version = "0.0.12"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.14 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/server
 
+## 0.0.14 - 2026-02-27
+
+### Added
+
+- `permissionMode` parameter on session creation API for configurable SDK permission mode (#34)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14, @ash-ai/sandbox@0.0.13
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ash-ai/shared
 
+## 0.0.14 - 2026-02-27
+
+### Added
+
+- `SandboxPermissionMode` type for configurable SDK permission modes (#34)
+- `permissionMode` field on `CreateSessionRequest` (#34)
+- `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS`, and `ASH_PERMISSION_MODE` added to sandbox env allowlist (#34)
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.9 - 2026-02-27
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.14, @ash-ai/sdk@0.0.14
+
 ## 0.0.8 - 2026-02-27
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

- Patch bump all packages
- Configurable SDK permission mode (`permissionMode` on session creation API, `ASH_PERMISSION_MODE` env var in bridge)
- Added `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS` to sandbox env allowlist
- New `SandboxPermissionMode` type in shared

## Packages

| Package | Version |
|---------|---------|
| @ash-ai/shared | 0.0.13 → 0.0.14 |
| @ash-ai/server | 0.0.13 → 0.0.14 |
| @ash-ai/sdk | 0.0.13 → 0.0.14 |
| @ash-ai/bridge | 0.0.12 → 0.0.13 |
| @ash-ai/cli | 0.0.12 → 0.0.13 |
| @ash-ai/sandbox | 0.0.12 → 0.0.13 |
| @ash-ai/runner | 0.0.12 → 0.0.13 |
| @ash-ai/mcp-server | 0.0.9 → 0.0.10 |
| @ash-ai/ui | 0.0.8 → 0.0.9 |
| ash-ai-sdk (PyPI) | 0.0.11 → 0.0.12 |

CI will create tags, GitHub releases, and publish to npm/PyPI after merge.