### PR TITLE
feat: redesign homepage, add version endpoint, fix bwrap fallback

### DIFF
--- a/packages/server/src/__tests__/openapi.test.ts
+++ b/packages/server/src/__tests__/openapi.test.ts
@@ -44,7 +44,7 @@ describe('OpenAPI spec generation', () => {
   it('has info section', () => {
     const info = spec.info as Record<string, string>;
     expect(info.title).toBe('Ash API');
-    expect(info.version).toBe('0.1.0');
+    expect(info.version).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it('has all expected paths', () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@ import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_PORT, DEFAULT_HOST, DEFAULT_DATA_DIR, DEFAULT_MAX_SANDBOXES, DEFAULT_IDLE_TIMEOUT_MS } from '@ash-ai/shared';
 import { createAshServer } from './server.js';
+import { VERSION } from './version.js';
 
 export { createAshServer } from './server.js';
 export type { AshServerOptions, AshServer } from './server.js';
@@ -37,7 +38,7 @@ process.on('SIGINT', async () => { await shutdown(); process.exit(0); });
 // Start
 try {
   await app.listen({ port, host });
-  app.log.info(`Ash server listening on ${host}:${port} (mode: ${mode})`);
+  app.log.info(`Ash v${VERSION} listening on ${host}:${port} (mode: ${mode})`);
   app.log.info(`Data directory: ${dataDir}`);
   if (mode === 'standalone') {
     app.log.info(`Bridge entry: ${bridgeEntry}`);

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -4,6 +4,7 @@ import type { SandboxPool } from '@ash-ai/sandbox';
 import type { PoolStats } from '@ash-ai/shared';
 import type { RunnerCoordinator } from '../runner/coordinator.js';
 import { listSessions } from '../db/index.js';
+import { VERSION } from '../version.js';
 
 const startTime = Date.now();
 /** Unique coordinator ID: hostname + PID. Useful for identifying which coordinator
@@ -34,6 +35,7 @@ export function healthRoutes(app: FastifyInstance, coordinator: RunnerCoordinato
 
     return reply.send({
       status: 'ok',
+      version: VERSION,
       coordinatorId,
       activeSessions: sessions.length,
       activeSandboxes: localPool?.activeCount ?? 0,

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto';
 import { SSE_WRITE_TIMEOUT_MS, timingEnabled, startTimer, logTiming } from '@ash-ai/shared';
 import { getAgent, insertSession, insertForkedSession, getSession, listSessions, updateSessionStatus, updateSessionSandbox, touchSession, updateSessionRunner, insertMessage, listMessages, insertSessionEvent, insertSessionEvents, listSessionEvents } from '../db/index.js';
 import { classifyBridgeMessage, classifyToStreamEvents } from '@ash-ai/shared';
+import { VERSION } from '../version.js';
 import type { RunnerCoordinator } from '../runner/coordinator.js';
 import type { TelemetryExporter } from '../telemetry/exporter.js';
 import { restoreSessionState, hasPersistedState, restoreStateFromCloud } from '@ash-ai/sandbox';
@@ -365,7 +366,7 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
     });
 
     // Emit session_start as first SSE event — clients know which session they're streaming
-    await writeSSE(reply.raw, `event: session_start\ndata: ${JSON.stringify({ sessionId: session.id })}\n\n`);
+    await writeSSE(reply.raw, `event: session_start\ndata: ${JSON.stringify({ sessionId: session.id, version: VERSION })}\n\n`);
 
     let eventCount = 0;
     let firstEventMs = 0;

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -98,6 +98,7 @@ const HealthResponseSchema = {
   type: 'object',
   properties: {
     status: { type: 'string', enum: ['ok'] },
+    version: { type: 'string', description: 'Ash server version' },
     coordinatorId: { type: 'string', description: 'Unique coordinator ID (hostname-PID)' },
     activeSessions: { type: 'integer' },
     activeSandboxes: { type: 'integer' },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -23,6 +23,7 @@ import { attachmentRoutes } from './routes/attachments.js';
 import { usageRoutes } from './routes/usage.js';
 import { workspaceRoutes } from './routes/workspace.js';
 import { createTelemetryExporter } from './telemetry/exporter.js';
+import { VERSION } from './version.js';
 
 export interface AshServerOptions {
   /** Data directory for sandboxes and state. Defaults to ASH_DATA_DIR or ~/.ash */
@@ -128,7 +129,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
       info: {
         title: 'Ash API',
         description: 'REST API for deploying and orchestrating hosted AI agents',
-        version: '0.1.0',
+        version: VERSION,
       },
       servers: [{ url: `http://localhost:${port}` }],
       tags: [

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'));
+
+export const VERSION: string = pkg.version;

--- a/packages/shared/src/__tests__/types.test.ts
+++ b/packages/shared/src/__tests__/types.test.ts
@@ -204,7 +204,7 @@ describe('classifyToStreamEvents', () => {
     expect(events[0]).toEqual({ type: 'thinking_delta', data: { delta: 'Hmm...' } });
   });
 
-  it('classifies assistant messages with mixed content', () => {
+  it('classifies assistant messages with mixed content (no text_delta for complete messages)', () => {
     const data = {
       type: 'assistant',
       message: {
@@ -216,7 +216,9 @@ describe('classifyToStreamEvents', () => {
     };
     const events = classifyToStreamEvents(data);
     const types = events.map((e) => e.type);
-    expect(types).toContain('text_delta');
+    // Complete assistant messages should NOT emit text_delta — text was already
+    // streamed incrementally via stream_event deltas. Only tool_use + raw message.
+    expect(types).not.toContain('text_delta');
     expect(types).toContain('tool_use');
     expect(types).toContain('message'); // always includes raw
   });

--- a/website/docs/comparisons/blaxel.md
+++ b/website/docs/comparisons/blaxel.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 2
+title: Ash vs Blaxel
+---
+
+# Ash vs Blaxel
+
+[Blaxel](https://blaxel.ai) and Ash both provide infrastructure for AI agents, but they make different tradeoffs. This page breaks down where they overlap, where they diverge, and when to use each.
+
+## TL;DR
+
+- **Ash** is a self-hostable agent platform -- deploy Claude agents as folders, get production APIs with sessions, streaming, sandboxing, and persistence on your own infrastructure. Sub-millisecond per-message overhead, 44ms cold start, 1.7ms warm resume.
+- **Blaxel** is a managed cloud platform -- serverless agent hosting, perpetual sandboxes, model gateway, and observability as a service.
+
+The core difference: Ash runs on your machines; Blaxel runs on theirs.
+
+## Different Tradeoffs
+
+| | Ash | Blaxel |
+|---|---|---|
+| **What it is** | Self-hostable agent orchestration | Managed cloud agent platform |
+| **Infrastructure model** | Your servers (Docker, EC2, GCE, bare metal) | Their cloud (serverless) |
+| **Agent definition** | Folder with `CLAUDE.md` | HTTP server (any framework) |
+| **AI model** | Claude (via Claude Code SDK) | Any model (model gateway) |
+| **Sandbox model** | OS-level (bubblewrap, cgroups) | MicroVMs |
+| **Session persistence** | SQLite/Postgres, survives restarts | Snapshot-based |
+| **Pricing** | Self-hosted (pay for compute + Claude API) | Usage-based SaaS |
+
+## Feature Comparison
+
+| Feature | Ash | Blaxel |
+|---|---|---|
+| **Agent hosting** | Yes -- deploy folders, get REST API | Yes -- serverless endpoints |
+| **Sandbox isolation** | Bubblewrap, cgroups v2, env allowlist | MicroVMs (EROFS + tmpfs) |
+| **Session creation (cold start)** | 44ms p50 (process spawn + bridge connect) | ~25ms (MicroVM resume) |
+| **Session resume (warm)** | 1.7ms p50 (DB lookup + status flip) | ~25ms (MicroVM resume) |
+| **Per-message overhead** | 0.41ms p50 (sub-millisecond) | Not published |
+| **Session persistence** | SQLite/Postgres, pause/resume | Snapshot-based, scale-to-zero |
+| **Streaming** | Native SSE with typed events, backpressure | Framework-dependent |
+| **Model support** | Claude (deep SDK integration) | Multi-model (gateway routing) |
+| **Observability** | Prometheus metrics, structured logs, `/health` | Built-in logs, traces, metrics |
+| **MCP servers** | Per-agent and per-session MCP config | Hosted MCP servers |
+| **Batch jobs** | Not built-in | Yes -- async compute |
+| **Multi-machine** | Built-in coordinator + runner | Managed by platform |
+| **SDKs** | TypeScript + Python | TypeScript + Python |
+| **CLI** | Full lifecycle management | Yes |
+| **Self-hostable** | Yes | No |
+| **Open source** | Yes | No |
+| **Data residency** | Full control (your machines) | Their cloud |
+
+## Architecture Differences
+
+### Ash
+
+```
+CLI/SDK  ──HTTP──>  Ash Server  ──in-process──>  SandboxPool  ──unix socket──>  Bridge  ──>  Claude Code SDK
+                    (your infra)                  (bubblewrap)                   (in sandbox)
+```
+
+Ash owns the full stack. Your server, your sandboxes, your data. The server manages sandbox lifecycle directly using OS-level isolation.
+
+### Blaxel
+
+```
+Your App  ──HTTP──>  Blaxel Cloud  ──>  Agent Endpoint (serverless)  ──>  Model Gateway  ──>  LLM Provider
+                     (their infra)      (MicroVM sandbox)
+```
+
+Blaxel is a managed platform. You deploy agents to their cloud, which handles scaling, sandboxing, routing, and observability.
+
+## When to Use Each
+
+### Use Ash when:
+
+- **You need infrastructure control** -- data must stay on your machines, compliance requirements, air-gapped environments
+- **You're building with Claude** -- Ash's deep Claude Code SDK integration gives you the full power of the SDK (sessions, tools, MCP, skills) with zero translation layer
+- **Sessions must persist across restarts** -- Ash's SQLite/Postgres persistence survives crashes, supports pause/resume, and enables multi-day sessions
+- **You want self-hosted, open source** -- inspect the code, modify the behavior, no vendor lock-in
+
+### Use Blaxel when:
+
+- **You want managed infrastructure** -- don't want to run your own servers, prefer pay-per-use
+- **You use multiple LLM providers** -- Blaxel's model gateway routes between providers with fallback and telemetry
+- **You want built-in observability** -- logs, traces, and metrics without setting up Prometheus or Grafana
+- **Framework flexibility matters** -- Blaxel hosts any HTTP server, not just Claude agents
+
+### Use Ash if you're unsure:
+
+Self-hosted means you can migrate away at any time. You're not locked into a platform. Start with Ash, and if you later need managed infrastructure, the migration path is straightforward since your agents are just folders.
+
+## Onboarding Comparison
+
+### Ash -- 4 commands
+
+```bash
+ash start
+ash deploy ./my-agent --name my-agent
+ash chat my-agent "Hello"
+```
+
+### Blaxel -- framework setup + deploy
+
+```bash
+bl login
+bl init my-agent
+# ... write HTTP server code ...
+bl deploy
+bl run my-agent --data '{"inputs": "Hello"}'
+```
+
+Ash's agent definition is simpler (a folder with `CLAUDE.md`) because it targets a specific SDK. Blaxel requires writing an HTTP server because it supports any framework.
+
+## Performance
+
+Ash publishes [real benchmarks](/guides/monitoring). Here's how the numbers compare:
+
+| Metric | Ash (measured) | Blaxel (claimed) |
+|---|---|---|
+| **Session creation** | 44ms p50 | ~25ms (MicroVM resume) |
+| **Warm resume** | 1.7ms p50 | ~25ms (MicroVM resume) |
+| **Cold resume** | 32ms p50 | Not published |
+| **Per-message overhead** | 0.41ms p50 | Not published |
+| **Pool operations** | 0.03ms p50 | Not published |
+
+Blaxel's 25ms number is for MicroVM resume from a snapshot. Ash's 1.7ms warm resume is actually faster because it's just a DB lookup + status flip -- the sandbox process is still alive. For cold starts (new session creation), Ash's 44ms and Blaxel's ~25ms are in the same ballpark. In both cases, the real latency users feel is dominated by the LLM API response time (~1-3 seconds), not the platform overhead.
+
+## Summary
+
+| Dimension | Ash | Blaxel |
+|---|---|---|
+| **Control** | Full (self-hosted, open source) | Managed (their cloud) |
+| **Simplicity** | Agent = folder with `CLAUDE.md` | Agent = HTTP server |
+| **AI model** | Claude (deep integration) | Any model (gateway) |
+| **Session creation** | 44ms p50 | ~25ms (claimed) |
+| **Warm resume** | 1.7ms p50 | ~25ms (claimed) |
+| **Per-message overhead** | 0.41ms p50 | Not published |
+| **Best for** | Teams who want control + Claude | Teams who want managed + multi-model |
+
+Both are solid choices. The decision comes down to whether you want to own the infrastructure or outsource it.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 0
+title: Introduction
+slug: /introduction
+---
+
+# What is Ash?
+
+Ash is a self-hostable system for deploying and orchestrating AI agents. You define an agent as a folder with a `CLAUDE.md` system prompt, deploy it to a server, and interact with it through a REST API, CLI, or SDKs. Every agent session runs inside an isolated sandbox.
+
+## Who is Ash For?
+
+Ash is for developers and teams who want to run Claude-powered agents in production without giving up control of their infrastructure.
+
+| If you need... | Ash gives you... |
+|---|---|
+| AI agents behind an API | REST endpoints with SSE streaming |
+| Stateful conversations | Sessions that persist, pause, resume, and survive restarts |
+| Security isolation | Sandboxes with cgroups, bubblewrap, and environment allowlists |
+| Full infrastructure control | Self-hosted on Docker, EC2, ECS, GCE, or bare metal |
+| Multi-language clients | TypeScript SDK, Python SDK, CLI, and raw curl |
+
+## Core Concepts at a Glance
+
+```mermaid
+graph LR
+    Agent["Agent<br/>(folder with CLAUDE.md)"]
+    Server["Ash Server<br/>(REST API)"]
+    Session["Session<br/>(stateful conversation)"]
+    Sandbox["Sandbox<br/>(isolated process)"]
+    Bridge["Bridge<br/>(Claude Code SDK)"]
+
+    Agent -->|deployed to| Server
+    Server -->|creates| Session
+    Session -->|runs in| Sandbox
+    Sandbox -->|contains| Bridge
+```
+
+- **Agent** -- A folder containing a `CLAUDE.md` system prompt and optional config. Like a Docker image: the blueprint, not the running instance.
+- **Session** -- A stateful conversation between a client and a deployed agent. Created, paused, resumed, or ended through the API.
+- **Sandbox** -- An isolated child process running a single session. Restricted environment, resource limits, filesystem isolation.
+- **Bridge** -- The process inside each sandbox that connects to the Claude Code SDK and streams responses back to the server.
+- **Server** -- The Fastify HTTP server that exposes the REST API, manages agents, routes sessions, and persists state.
+
+## Key Differentiators
+
+### Self-Hosted, Not SaaS
+
+Ash runs on your infrastructure. Docker, EC2, ECS Fargate, GCE, or bare metal. Your data stays on your machines. No vendor lock-in, no external API gateway, no third-party dependencies beyond the Claude API itself.
+
+### Agent = Folder
+
+No YAML manifests, no complex deployment pipelines. An agent is a directory with a `CLAUDE.md` file. Add `.claude/settings.json` for permissions, `.mcp.json` for MCP tools, and `.claude/skills/` for reusable workflows. Deploy with `ash deploy ./my-agent`.
+
+### Sessions That Survive
+
+Sessions persist to SQLite or Postgres. They survive server restarts, can be paused and resumed days later, and hand off between machines in a multi-runner setup. Warm resume is 1.7ms (sandbox still alive). Cold resume is 32ms (new process + state restoration).
+
+### Fast by Default
+
+Ash adds sub-millisecond overhead per message (0.41ms p50). Session creation is 44ms. Pool operations are microsecond-scale. The latency users feel is dominated by the LLM API, not Ash. See the [benchmarks](/guides/monitoring) for full numbers.
+
+### Real Isolation
+
+Every session sandbox runs with an environment allowlist (host credentials never leak in), cgroups v2 resource limits on Linux, and bubblewrap filesystem isolation. The agent inside the sandbox is treated as untrusted code.
+
+### Thin Wrapper Philosophy
+
+Ash wraps the Claude Code SDK without reinventing it. SDK types flow through the system unchanged -- from bridge to server to client. Ash adds orchestration (sessions, sandboxes, streaming, persistence) but does not translate or redefine the AI layer.
+
+## Quick Example
+
+```bash
+# Install and start the server
+npm install -g @ash-ai/cli
+ash start
+
+# Define an agent (one file is all you need)
+mkdir my-agent
+echo "You are a helpful coding assistant." > my-agent/CLAUDE.md
+
+# Deploy and chat
+ash deploy ./my-agent --name my-agent
+ash chat my-agent "Explain closures in JavaScript"
+```
+
+The response streams back in real time. Under the hood, Ash deploys the agent to its registry, spawns an isolated sandbox, starts a bridge process with your `CLAUDE.md` as the system prompt, and proxies the Claude SDK's streaming response as SSE events.
+
+## How Does Ash Compare?
+
+| | Ash | Generic Sandbox APIs | Managed Agent Platforms |
+|---|---|---|---|
+| **Focus** | AI agent orchestration | Code execution | Agent hosting |
+| **Infrastructure** | Self-hosted | Cloud/SaaS | Cloud/SaaS |
+| **Session model** | Persistent, resumable | Ephemeral | Varies |
+| **Isolation** | OS-level (cgroups, bwrap) | Provider-dependent | Provider-dependent |
+| **AI integration** | Deep (Claude Code SDK) | None (BYO) | Framework-specific |
+| **Data control** | Full (your machines) | Partial | Limited |
+
+For detailed comparisons, see [Ash vs ComputeSDK](/comparisons/computesdk) and [Ash vs Blaxel](/comparisons/blaxel).
+
+## Next Steps
+
+- **[Installation](/getting-started/installation)** -- Get the CLI installed and the server running
+- **[Quickstart](/getting-started/quickstart)** -- Deploy your first agent in two minutes
+- **[Key Concepts](/getting-started/concepts)** -- Deep dive into agents, sessions, sandboxes, and bridges
+- **[Architecture](/architecture/overview)** -- How all the pieces fit together

--- a/website/docs/use-cases.md
+++ b/website/docs/use-cases.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 4
+title: Use Cases
+---
+
+# Use Cases
+
+Ash is a general-purpose platform for deploying AI agents. Here are common patterns for what you can build.
+
+## Customer Support Agent
+
+Deploy an agent that handles support tickets, looks up account data via MCP tools, and follows your company's support playbook.
+
+```
+support-agent/
+  CLAUDE.md                  # Support playbook and escalation rules
+  .mcp.json                  # Connect to CRM, knowledge base
+  .claude/
+    settings.json            # Allow: WebFetch, mcp__crm__*, mcp__kb__*
+    skills/
+      lookup-account.md      # /lookup-account workflow
+      process-refund.md      # /process-refund workflow
+```
+
+**Why Ash:** Each support conversation is a persistent session. If the customer comes back later, resume the session with full context. The agent runs in an isolated sandbox, so it can't access other customers' data. MCP servers connect the agent to your CRM and knowledge base without exposing raw database access.
+
+## Code Review Bot
+
+Build a bot that reviews pull requests, clones repos into sandboxes, runs tests, and posts structured feedback.
+
+```typescript
+// Triggered by GitHub webhook
+const session = await client.createSession('code-reviewer');
+
+for await (const event of client.sendMessageStream(
+  session.id,
+  `Review this PR:\n${prDiff}\n\nClone the repo and run tests.`,
+)) {
+  // Stream review results back to your webhook handler
+}
+
+// Post the review to GitHub, then clean up
+await client.endSession(session.id);
+```
+
+**Why Ash:** Sandbox isolation means the agent can clone repos and run `npm test` without affecting your host. Each review gets its own sandbox with its own filesystem. Streaming lets you show review progress in real time.
+
+## Research Assistant with Memory
+
+Deploy an agent that searches the web, synthesizes findings, and remembers context across sessions using an MCP memory server.
+
+```
+research-agent/
+  CLAUDE.md                  # Research methodology and output format
+  .mcp.json                  # fetch + memory MCP servers
+  .claude/
+    settings.json            # Allow: WebFetch, mcp__fetch__*, mcp__memory__*
+    skills/
+      search-and-summarize/
+        SKILL.md             # /search-and-summarize workflow
+      write-memo/
+        SKILL.md             # /write-memo workflow
+```
+
+**Why Ash:** Sessions persist across restarts. Pause a research session, come back days later, and resume where you left off. The memory MCP server stores facts persistently inside the sandbox workspace, building knowledge over time.
+
+## Multi-Tenant SaaS Integration
+
+Build a SaaS feature where each of your customers gets their own AI assistant, with tenant-specific tools injected via per-session MCP servers.
+
+```typescript
+// For each customer request, inject their specific MCP tools
+const session = await client.createSession('assistant', {
+  mcpServers: {
+    'customer-api': {
+      command: 'npx',
+      args: ['-y', '@your-org/customer-mcp', '--tenant', customerId],
+      env: {
+        CUSTOMER_TOKEN: customerToken,
+      },
+    },
+  },
+});
+```
+
+**Why Ash:** Per-session MCP servers let you inject tenant-specific tools at runtime without redeploying the agent. Each customer's session runs in its own sandbox with its own environment, so credentials never cross boundaries.
+
+## Data Processing Pipeline
+
+Run agents that ingest data, execute analysis in sandboxed environments, and stream results back to your application.
+
+```typescript
+const session = await client.createSession('data-analyst');
+
+// Upload a CSV to the sandbox
+await client.uploadFile(session.id, '/workspace/data.csv', csvBuffer);
+
+// Ask the agent to analyze it
+for await (const event of client.sendMessageStream(
+  session.id,
+  'Analyze data.csv. Calculate summary statistics, identify outliers, and produce a report.',
+)) {
+  if (event.type === 'message') {
+    const text = extractTextFromEvent(event.data);
+    if (text) process.stdout.write(text);
+  }
+}
+
+// Download the generated report
+const report = await client.downloadFile(session.id, '/workspace/report.md');
+```
+
+**Why Ash:** The agent can install Python packages, write scripts, and execute code inside the sandbox without affecting your host system. File upload/download APIs let you pass data in and pull results out. Streaming shows progress as the analysis runs.
+
+## Background Automation Agent
+
+Deploy a long-running agent that monitors systems, runs periodic checks, and takes action when needed.
+
+```
+monitor-agent/
+  CLAUDE.md                  # Monitoring procedures and alert rules
+  .claude/
+    settings.json            # Allow: Bash(*), WebFetch, mcp__slack__*
+  .mcp.json                  # Slack MCP server for alerts
+```
+
+```typescript
+// Create a long-lived session
+const session = await client.createSession('monitor-agent');
+
+// Send periodic check instructions
+setInterval(async () => {
+  for await (const event of client.sendMessageStream(
+    session.id,
+    'Run your health checks and report any issues to Slack.',
+  )) {
+    // Log results
+  }
+}, 5 * 60 * 1000); // Every 5 minutes
+```
+
+**Why Ash:** The session persists indefinitely. The agent builds context over time -- it knows what it checked last, what's normal, and what's changed. Pause the session during maintenance windows and resume after.
+
+## Patterns to Notice
+
+Across all use cases, a few patterns repeat:
+
+1. **Agent as folder** -- Define behavior in `CLAUDE.md`, not code. Change the prompt, redeploy, done.
+2. **Session persistence** -- Long-lived, resumable conversations are the default, not a special case.
+3. **Sandbox isolation** -- Agents run untrusted code safely. Clone repos, run scripts, install packages.
+4. **MCP servers** -- Connect agents to your systems (CRM, databases, APIs) through a standard protocol.
+5. **Streaming** -- Real-time responses via SSE. Show progress, not just final answers.
+
+## Next Steps
+
+- **[Quickstart](/getting-started/quickstart)** -- Deploy your first agent
+- **[Defining an Agent](/guides/defining-an-agent)** -- Full guide to agent structure
+- **[Managing Sessions](/guides/managing-sessions)** -- Session lifecycle and persistence
+- **[Streaming Responses](/guides/streaming-responses)** -- SSE events and SDK helpers

--- a/website/plugins/llm-txt-plugin.js
+++ b/website/plugins/llm-txt-plugin.js
@@ -10,6 +10,7 @@ const DOC_SECTIONS = [
       { id: 'getting-started/installation', title: 'Installation', desc: 'Install the Ash CLI and SDK' },
       { id: 'getting-started/quickstart', title: 'Quickstart', desc: 'Deploy your first agent in minutes' },
       { id: 'getting-started/concepts', title: 'Key Concepts', desc: 'Agents, sessions, sandboxes, and streaming' },
+      { id: 'use-cases', title: 'Use Cases', desc: 'Common patterns and examples for building with Ash' },
     ],
   },
   {
@@ -84,6 +85,7 @@ const OPTIONAL_SECTIONS = [
     section: 'Comparisons',
     docs: [
       { id: 'comparisons/computesdk', title: 'Ash vs ComputeSDK', desc: 'Feature comparison with Anthropic ComputeSDK' },
+      { id: 'comparisons/blaxel', title: 'Ash vs Blaxel', desc: 'Feature comparison with Blaxel managed agent platform' },
     ],
   },
   {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
       href: 'https://github.com/ash-ai-org/ash-ai/releases',
       className: 'sidebar-link-changelog',
     },
+    'introduction',
     {
       type: 'category',
       label: 'Getting Started',
@@ -48,6 +49,7 @@ const sidebars: SidebarsConfig = {
         'guides/monitoring',
       ],
     },
+    'use-cases',
     {
       type: 'category',
       label: 'Self-Hosting',
@@ -113,6 +115,7 @@ const sidebars: SidebarsConfig = {
       label: 'Comparisons',
       items: [
         'comparisons/computesdk',
+        'comparisons/blaxel',
       ],
     },
     {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -286,6 +286,11 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z'%3E%3C/path%3E%3Cpath d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z'%3E%3C/path%3E%3C/svg%3E") !important;
 }
 
+/* Use Cases - lightbulb */
+.theme-doc-sidebar-menu .menu__link[href="/use-cases"]::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='9' y1='18' x2='15' y2='18'%3E%3C/line%3E%3Cline x1='10' y1='22' x2='14' y2='22'%3E%3C/line%3E%3Cpath d='M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5A4.61 4.61 0 0 1 8.91 14'%3E%3C/path%3E%3C/svg%3E") !important;
+}
+
 /* Quickstart - lightning bolt (lime green) */
 .theme-doc-sidebar-menu .menu__link[href*="quickstart"]::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23ccff00' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolygon points='13 2 3 14 12 14 11 22 21 10 12 10 13 2'%3E%3C/polygon%3E%3C/svg%3E") !important;
@@ -445,7 +450,7 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='8' y1='6' x2='21' y2='6'%3E%3C/line%3E%3Cline x1='8' y1='12' x2='21' y2='12'%3E%3C/line%3E%3Cline x1='8' y1='18' x2='21' y2='18'%3E%3C/line%3E%3Cline x1='3' y1='6' x2='3.01' y2='6'%3E%3C/line%3E%3Cline x1='3' y1='12' x2='3.01' y2='12'%3E%3C/line%3E%3Cline x1='3' y1='18' x2='3.01' y2='18'%3E%3C/line%3E%3C/svg%3E") !important;
 }
 
-/* Comparisons - scale */
+/* Comparisons - bar chart */
 .theme-doc-sidebar-menu .menu__link[href*="comparisons"]::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='18' y1='20' x2='18' y2='10'%3E%3C/line%3E%3Cline x1='12' y1='20' x2='12' y2='4'%3E%3C/line%3E%3Cline x1='6' y1='20' x2='6' y2='14'%3E%3C/line%3E%3C/svg%3E") !important;
 }
@@ -1285,55 +1290,385 @@ article .markdown header h1 {
 /* ============================================
    Homepage
    ============================================ */
-.hero--primary {
-  background-color: var(--ash-surface-dark) !important;
-  color: rgba(255, 255, 255, 0.85);
-}
 
-.hero__title {
-  @apply font-semibold text-white;
-  font-size: 3.5rem !important;
-  letter-spacing: -0.04em;
-}
-
-.hero__subtitle {
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 1.125rem;
-  max-width: 640px;
-  margin: 0 auto 2rem;
-  line-height: 1.6;
-}
-
-.features {
-  display: flex;
-  align-items: center;
-  padding: 2rem 0;
-  width: 100%;
+/* Hide sidebar and doc-specific elements on homepage */
+.home-page {
   background-color: var(--ash-surface-dark);
 }
 
-.feature-card {
-  @apply rounded-xl border;
-  padding: 1.5rem;
+/* Hero Section */
+.hero-section {
+  padding: 6rem 2rem 4rem;
   text-align: center;
-  background-color: var(--ash-surface-card);
-  border-color: var(--ash-surface-border) !important;
+  background: radial-gradient(ellipse at 50% 0%, rgba(204, 255, 0, 0.06) 0%, transparent 60%);
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-badge {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ash-accent);
+  background-color: rgba(204, 255, 0, 0.1);
+  border: 1px solid rgba(204, 255, 0, 0.2);
+  border-radius: 100px;
+  padding: 0.375rem 1rem;
+  margin-bottom: 2rem;
+}
+
+.hero-title {
+  font-size: 3.5rem !important;
+  font-weight: 700 !important;
+  color: white !important;
+  letter-spacing: -0.04em !important;
+  line-height: 1.1 !important;
+  margin-bottom: 1.5rem !important;
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+}
+
+.hero-accent {
+  color: var(--ash-accent);
+}
+
+.hero-description {
+  font-size: 1.125rem !important;
+  color: rgba(255, 255, 255, 0.55) !important;
+  line-height: 1.7 !important;
+  max-width: 640px;
+  margin: 0 auto 2.5rem !important;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 4rem;
+}
+
+.hero-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 2rem;
+  font-size: 15px;
+  font-weight: 600;
+  color: black !important;
+  background-color: var(--ash-accent);
+  border-radius: 0.5rem;
+  text-decoration: none !important;
   transition: all 0.15s ease;
 }
 
-.feature-card:hover {
-  border-color: rgba(255, 255, 255, 0.15) !important;
+.hero-btn-primary:hover {
+  background-color: var(--ash-accent-500);
+  color: black !important;
+  text-decoration: none !important;
+}
+
+.hero-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 2rem;
+  font-size: 15px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8) !important;
+  background-color: transparent;
+  border: 1px solid var(--ash-surface-border);
+  border-radius: 0.5rem;
+  text-decoration: none !important;
+  transition: all 0.15s ease;
+}
+
+.hero-btn-secondary:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: white !important;
+  text-decoration: none !important;
+}
+
+/* Hero Terminal */
+.hero-terminal {
+  max-width: 640px;
+  margin: 0 auto;
+  border-radius: 0.75rem;
+  border: 1px solid var(--ash-surface-border);
+  overflow: hidden;
+  text-align: left;
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  background-color: #161616;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.terminal-dots .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dots .dot.red { background: #ff5f56; }
+.terminal-dots .dot.yellow { background: #ffbd2e; }
+.terminal-dots .dot.green { background: #27ca40; }
+
+.terminal-title {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.35);
+  font-weight: 500;
+}
+
+.terminal-body {
+  padding: 1.25rem 1.5rem;
+  background-color: #0c0c0c;
+}
+
+.terminal-body code {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13px;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.7) !important;
+  background: none !important;
+  padding: 0 !important;
+  white-space: pre-wrap;
+}
+
+.terminal-prompt {
+  color: var(--ash-accent) !important;
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.terminal-output {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+.terminal-session {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+/* Features Section */
+.features-section {
+  padding: 4rem 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.home-feature-card {
+  padding: 1.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--ash-surface-border);
+  background-color: var(--ash-surface-card);
+  transition: all 0.15s ease;
+}
+
+.home-feature-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
   background-color: var(--ash-surface-elevated);
 }
 
-.feature-card h3 {
-  @apply font-semibold text-white;
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
+.home-feature-icon {
+  font-size: 1.75rem;
+  margin-bottom: 1rem;
+  line-height: 1;
 }
 
-.feature-card p {
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 0.875rem;
-  line-height: 1.6;
+.home-feature-card h3 {
+  font-size: 1rem !important;
+  font-weight: 600 !important;
+  color: white !important;
+  margin-bottom: 0.5rem !important;
+  margin-top: 0 !important;
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+}
+
+.home-feature-card p {
+  font-size: 0.875rem !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  line-height: 1.6 !important;
+  margin-bottom: 0 !important;
+}
+
+/* Architecture Section */
+.architecture-section {
+  padding: 4rem 2rem;
+  text-align: center;
+  border-top: 1px solid var(--ash-surface-border);
+}
+
+.architecture-section h2 {
+  font-size: 1.75rem !important;
+  font-weight: 700 !important;
+  color: white !important;
+  margin-bottom: 0.75rem !important;
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+}
+
+.architecture-subtitle {
+  font-size: 1rem !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  max-width: 600px;
+  margin: 0 auto 3rem !important;
+}
+
+.architecture-diagram {
+  max-width: 900px;
+  margin: 0 auto 2rem;
+}
+
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.arch-node {
+  padding: 1.25rem 1.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--ash-surface-border);
+  background-color: var(--ash-surface-card);
+  min-width: 140px;
+}
+
+.arch-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: white;
+}
+
+.arch-sublabel {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.4);
+  margin-top: 0.25rem;
+}
+
+.arch-node.arch-server {
+  border-color: var(--ash-accent);
+  background-color: rgba(204, 255, 0, 0.05);
+}
+
+.arch-arrow {
+  font-size: 1.5rem;
+  color: rgba(255, 255, 255, 0.25);
+  padding: 0 0.25rem;
+}
+
+.architecture-cta {
+  margin-top: 2rem;
+}
+
+/* Use Cases Section */
+.use-cases-section {
+  padding: 4rem 2rem;
+  text-align: center;
+  border-top: 1px solid var(--ash-surface-border);
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.use-cases-section h2 {
+  font-size: 1.75rem !important;
+  font-weight: 700 !important;
+  color: white !important;
+  margin-bottom: 2rem !important;
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+}
+
+.use-cases-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+  text-align: left;
+  margin-bottom: 2.5rem;
+}
+
+.use-case-card {
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--ash-surface-border);
+  background-color: var(--ash-surface-card);
+}
+
+.use-case-card h3 {
+  font-size: 0.9375rem !important;
+  font-weight: 600 !important;
+  color: white !important;
+  margin-bottom: 0.5rem !important;
+  margin-top: 0 !important;
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+}
+
+.use-case-card p {
+  font-size: 0.8125rem !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  line-height: 1.6 !important;
+  margin-bottom: 0 !important;
+}
+
+.use-cases-cta {
+  margin-top: 1rem;
+}
+
+/* Homepage responsive */
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 2.25rem !important;
+  }
+
+  .hero-description {
+    font-size: 1rem !important;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .use-cases-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .arch-flow {
+    flex-direction: column;
+  }
+
+  .arch-arrow {
+    transform: rotate(90deg);
+  }
+}
+
+@media (min-width: 769px) and (max-width: 996px) {
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,5 +1,187 @@
-import { Redirect } from '@docusaurus/router';
+import React from 'react';
+import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from '@theme/Layout';
+
+function HeroSection() {
+  return (
+    <div className="hero-section">
+      <div className="hero-content">
+        <div className="hero-badge">Open Source</div>
+        <h1 className="hero-title">
+          Deploy and orchestrate
+          <br />
+          <span className="hero-accent">AI agents</span>
+        </h1>
+        <p className="hero-description">
+          Ash is a self-hostable platform for deploying Claude-powered agents as production APIs.
+          Define an agent as a folder, deploy it with one command, and get sessions, streaming,
+          sandboxing, and persistence out of the box.
+        </p>
+        <div className="hero-actions">
+          <Link className="hero-btn-primary" to="/getting-started/quickstart">
+            Get Started
+          </Link>
+          <Link className="hero-btn-secondary" to="/introduction">
+            Learn More
+          </Link>
+        </div>
+        <div className="hero-terminal">
+          <div className="terminal-header">
+            <div className="terminal-dots">
+              <span className="dot red" />
+              <span className="dot yellow" />
+              <span className="dot green" />
+            </div>
+            <span className="terminal-title">Terminal</span>
+          </div>
+          <div className="terminal-body">
+            <code>
+              <span className="terminal-prompt">$</span> ash deploy ./my-agent --name my-agent
+              {'\n'}
+              <span className="terminal-prompt">$</span> ash chat my-agent "What is a closure in JavaScript?"
+              {'\n'}
+              <span className="terminal-output">A closure is a function that retains access to variables from its</span>
+              {'\n'}
+              <span className="terminal-output">enclosing scope, even after the outer function has returned...</span>
+              {'\n'}
+              <span className="terminal-session">Session: 550e8400-e29b-41d4-a716-446655440000</span>
+            </code>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FeatureCard({ title, description, icon }: { title: string; description: string; icon: string }) {
+  return (
+    <div className="home-feature-card">
+      <div className="home-feature-icon">{icon}</div>
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+function FeaturesSection() {
+  return (
+    <div className="features-section">
+      <div className="features-grid">
+        <FeatureCard
+          icon="&#x1F4E6;"
+          title="Agent = Folder"
+          description="Define agents as folders with a CLAUDE.md system prompt. Add skills, MCP servers, and permissions. Deploy with one command."
+        />
+        <FeatureCard
+          icon="&#x1F512;"
+          title="Sandboxed Isolation"
+          description="Every session runs in an isolated sandbox with cgroups, bubblewrap, and environment allowlists. Untrusted code can't escape."
+        />
+        <FeatureCard
+          icon="&#x1F504;"
+          title="Persistent Sessions"
+          description="Sessions survive server restarts, pause and resume days later, and hand off between machines. State is persisted to SQLite or Postgres."
+        />
+        <FeatureCard
+          icon="&#x26A1;"
+          title="Sub-millisecond Overhead"
+          description="0.41ms per-message overhead. 44ms session creation. 1.7ms warm resume. Ash adds almost nothing on top of the LLM API latency."
+        />
+        <FeatureCard
+          icon="&#x1F3E0;"
+          title="Self-Hosted"
+          description="Run on your infrastructure. Docker, EC2, ECS Fargate, or bare metal. Your data stays on your machines. No external dependencies."
+        />
+        <FeatureCard
+          icon="&#x1F527;"
+          title="SDKs & CLI"
+          description="TypeScript and Python SDKs, a full-featured CLI, REST API with Swagger docs, and OpenAPI spec for code generation."
+        />
+      </div>
+    </div>
+  );
+}
+
+function ArchitectureSection() {
+  return (
+    <div className="architecture-section">
+      <h2>How It Works</h2>
+      <p className="architecture-subtitle">
+        A thin wrapper around the Claude Code SDK. Ash adds orchestration &mdash; sessions, sandboxes, streaming &mdash; without reinventing the AI layer.
+      </p>
+      <div className="architecture-diagram">
+        <div className="arch-flow">
+          <div className="arch-node arch-client">
+            <div className="arch-label">CLI / SDK / Browser</div>
+          </div>
+          <div className="arch-arrow">&rarr;</div>
+          <div className="arch-node arch-server">
+            <div className="arch-label">Ash Server</div>
+            <div className="arch-sublabel">REST API + SSE</div>
+          </div>
+          <div className="arch-arrow">&rarr;</div>
+          <div className="arch-node arch-sandbox">
+            <div className="arch-label">Sandbox</div>
+            <div className="arch-sublabel">Isolated Process</div>
+          </div>
+          <div className="arch-arrow">&rarr;</div>
+          <div className="arch-node arch-bridge">
+            <div className="arch-label">Bridge</div>
+            <div className="arch-sublabel">Claude Code SDK</div>
+          </div>
+        </div>
+      </div>
+      <div className="architecture-cta">
+        <Link className="hero-btn-secondary" to="/architecture/overview">
+          View Architecture Docs
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function UseCasesSection() {
+  return (
+    <div className="use-cases-section">
+      <h2>What You Can Build</h2>
+      <div className="use-cases-grid">
+        <div className="use-case-card">
+          <h3>Customer Support Agents</h3>
+          <p>Deploy agents that handle support tickets, look up account data via MCP tools, and escalate when needed.</p>
+        </div>
+        <div className="use-case-card">
+          <h3>Code Review Bots</h3>
+          <p>Agents that review PRs, run tests in sandboxes, and post structured feedback. Each review gets its own isolated session.</p>
+        </div>
+        <div className="use-case-card">
+          <h3>Research Assistants</h3>
+          <p>Persistent agents with memory that search the web, synthesize findings, and build knowledge over multiple sessions.</p>
+        </div>
+        <div className="use-case-card">
+          <h3>Data Processing Pipelines</h3>
+          <p>Agents that ingest data, run analysis in sandboxed environments, and stream results back to your application.</p>
+        </div>
+      </div>
+      <div className="use-cases-cta">
+        <Link className="hero-btn-primary" to="/getting-started/quickstart">
+          Start Building
+        </Link>
+      </div>
+    </div>
+  );
+}
 
 export default function Home(): JSX.Element {
-  return <Redirect to="/getting-started/quickstart" />;
+  const { siteConfig } = useDocusaurusContext();
+  return (
+    <Layout title="Home" description={siteConfig.tagline}>
+      <main className="home-page">
+        <HeroSection />
+        <FeaturesSection />
+        <ArchitectureSection />
+        <UseCasesSection />
+      </main>
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary
- Redesigned the website homepage with a hero section, features grid, architecture diagram, and use cases section
- Added `version` field to the health endpoint response and `session_start` SSE event (reads from package.json)
- Added bwrap-less cgroups-only fallback for Linux environments like Fargate where bwrap can't create namespaces
- Fixed duplicate `text_delta` emission in `classifyToStreamEvents` for complete assistant messages
- Added new website docs: introduction page, use cases page, and Blaxel comparison

## Test plan
- [ ] Verify website builds and homepage renders correctly
- [ ] Verify health endpoint returns version field
- [ ] Verify SSE session_start event includes version
- [ ] Verify sandbox spawns in cgroups-only mode when bwrap is unavailable on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)