### PR TITLE
release: v0.0.15

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.14 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15
+
 ## 0.0.13 - 2026-02-27
 
 ### Added

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.14 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.11 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15, @ash-ai/sdk@0.0.15
+
 ## 0.0.10 - 2026-02-27
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.14 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15, @ash-ai/sandbox@0.0.14
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/sandbox
 
+## 0.0.14 - 2026-02-28
+
+### Changed
+
+- Allow cgroups-only fallback on Linux when bwrap is unavailable (e.g. Fargate) (#39)
+- Updated dependencies: @ash-ai/shared@0.0.15
+
 ## 0.0.13 - 2026-02-27
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.13 - 2026-02-28
+
+### Changed
+
+- Patch version bump (no direct changes)
+
 ## 0.0.12 - 2026-02-27
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.12"
+version = "0.0.13"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.15 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15
+
 ## 0.0.14 - 2026-02-27
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ash-ai/server
 
+## 0.0.15 - 2026-02-28
+
+### Added
+
+- `version` field in health endpoint response (#39)
+- Server version included in `session_start` SSE event (#39)
+- `version.ts` module that reads version from package.json (#39)
+
+### Changed
+
+- OpenAPI spec version now matches package version (#39)
+- Startup log shows `Ash vX.Y.Z` instead of `Ash server` (#39)
+- Updated dependencies: @ash-ai/shared@0.0.15, @ash-ai/sandbox@0.0.14
+
 ## 0.0.14 - 2026-02-27
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ash-ai/shared
 
+## 0.0.15 - 2026-02-28
+
+### Fixed
+
+- Stop emitting duplicate `text_delta` events for complete assistant messages in `classifyToStreamEvents` (#39)
+
+### Changed
+
+- Added `version` field to `AshSessionStartEvent` type (#39)
+
 ## 0.0.14 - 2026-02-27
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.10 - 2026-02-28
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.15, @ash-ai/sdk@0.0.15
+
 ## 0.0.9 - 2026-02-27
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- Version bumps and CHANGELOG updates for all packages

### Key changes in this release
- **@ash-ai/shared**: Fix duplicate `text_delta` in `classifyToStreamEvents`, add `version` to session start type
- **@ash-ai/server**: Add version to health endpoint, session_start SSE event, and OpenAPI spec
- **@ash-ai/sandbox**: Allow cgroups-only fallback when bwrap is unavailable (Fargate support)

### Versions
| Package | Version |
|---------|---------|
| @ash-ai/shared | 0.0.15 |
| @ash-ai/server | 0.0.15 |
| @ash-ai/sdk | 0.0.15 |
| @ash-ai/sandbox | 0.0.14 |
| @ash-ai/bridge | 0.0.14 |
| @ash-ai/cli | 0.0.14 |
| @ash-ai/runner | 0.0.14 |
| @ash-ai/mcp-server | 0.0.11 |
| @ash-ai/ui | 0.0.10 |
| ash-ai-sdk | 0.0.13 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)