### PR TITLE
docs: add PyPI and npm links to SDK references

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ research-agent/
 | **REST API + OpenAPI** | Full API with Swagger UI at `/docs`. Auth, CORS, typed endpoints — production-ready out of the box. |
 | **Sandbox pool** | DB-backed pool with capacity limits, LRU eviction, idle sweep. Sandboxes reused across messages. |
 | **Multi-runner** | Scale horizontally. Add runner nodes, the coordinator routes sessions to the least-loaded one. |
-| **TypeScript + Python SDKs** | First-class clients for both languages. `npm install @ash-ai/sdk` / `pip install ash-ai-sdk` |
+| **TypeScript + Python SDKs** | First-class clients for both languages. [`npm install @ash-ai/sdk`](https://www.npmjs.com/package/@ash-ai/sdk) / [`pip install ash-ai-sdk`](https://pypi.org/project/ash-ai-sdk/) |
 | **One-command cloud deploy** | Deploy to EC2 or GCE with included scripts. Or run anywhere Docker runs. |
 
 ## Using the SDK

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -96,7 +96,7 @@ const client = new AshClient({
 });
 ```
 
-### Python SDK
+### [Python SDK](https://pypi.org/project/ash-ai-sdk/)
 
 ```python
 from ash_sdk import AshClient

--- a/docs/features/openapi-spec.md
+++ b/docs/features/openapi-spec.md
@@ -83,9 +83,9 @@ make openapi
 pnpm --filter '@ash-ai/server' openapi
 ```
 
-## Python SDK
+## [Python SDK](https://pypi.org/project/ash-ai-sdk/)
 
-The Python SDK at `packages/sdk-python/` has hand-written models and a streaming SSE parser. The `generate.sh` script can optionally regenerate models from the OpenAPI spec using `openapi-python-client`.
+The Python SDK at `packages/sdk-python/` ([PyPI](https://pypi.org/project/ash-ai-sdk/)) has hand-written models and a streaming SSE parser. The `generate.sh` script can optionally regenerate models from the OpenAPI spec using `openapi-python-client`.
 
 ## Known Limitations
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ for await (const event of client.sendMessageStream(session.id, 'What is a closur
 await client.endSession(session.id);
 ```
 
-### Option C: Python SDK
+### Option C: [Python SDK](https://pypi.org/project/ash-ai-sdk/)
 
 ```bash
 pip install ash-ai-sdk

--- a/docs/guides/connecting.md
+++ b/docs/guides/connecting.md
@@ -147,7 +147,7 @@ for await (const event of client.sendMessageStream(sessionId, 'Hello')) {
 }
 ```
 
-## Option B: Python SDK
+## Option B: [Python SDK](https://pypi.org/project/ash-ai-sdk/)
 
 ### Install
 

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -139,6 +139,7 @@ The SDK covers all Ash API endpoints:
 
 ## Links
 
-- [Documentation](https://ash.dev/docs/sdks/python)
+- [PyPI](https://pypi.org/project/ash-ai-sdk/)
+- [Documentation](https://pypi.org/project/ash-ai-sdk/)
 - [GitHub](https://github.com/ash-ai-org/ash-ai)
 - [TypeScript SDK](https://www.npmjs.com/package/@ash-ai/sdk)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -31,7 +31,7 @@ await client.endSession(session.id);
 
 ## Documentation
 
-See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation, including the [Python SDK](https://pypi.org/project/ash-ai/).
+See the [Ash README](https://github.com/ash-ai-org/ash-ai) for full documentation, including the [Python SDK](https://pypi.org/project/ash-ai-sdk/).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Link SDK mentions in README and docs to their published package pages on [PyPI](https://pypi.org/project/ash-ai-sdk/) and [npm](https://www.npmjs.com/package/@ash-ai/sdk)
- Fix incorrect Python SDK PyPI URL in TypeScript SDK README (`ash-ai` → `ash-ai-sdk`)

## Test plan
- [ ] Verify all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)