### PR TITLE
Add per-tenant API key provisioning endpoint

### DIFF
--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -1,0 +1,41 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import { generateApiKey, hashApiKey } from '../auth.js';
+import { insertApiKey } from '../db/index.js';
+
+const internalSecret = process.env.ASH_INTERNAL_SECRET;
+
+function validateInternalAuth(req: FastifyRequest, reply: FastifyReply): boolean {
+  if (!internalSecret) return true;
+  const auth = req.headers.authorization;
+  if (!auth || auth !== `Bearer ${internalSecret}`) {
+    reply.status(401).send({ error: 'Unauthorized — invalid or missing internal secret' });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Internal endpoint for provisioning per-tenant API keys.
+ * Called by the platform to lazily create Ash API keys for each tenant.
+ * Protected by ASH_INTERNAL_SECRET when set.
+ */
+export function apiKeyRoutes(app: FastifyInstance): void {
+  app.post('/api/internal/api-keys', async (req, reply) => {
+    if (!validateInternalAuth(req, reply)) return;
+
+    const { tenantId, label } = req.body as { tenantId: string; label?: string };
+    if (!tenantId || typeof tenantId !== 'string') {
+      return reply.status(400).send({ error: 'Missing required field: tenantId' });
+    }
+
+    const plainKey = generateApiKey();
+    const hmacSecret = process.env.ASH_CREDENTIAL_KEY;
+    const keyHash = hashApiKey(plainKey, hmacSecret);
+    const id = randomUUID();
+
+    const record = await insertApiKey(id, tenantId, keyHash, label || `platform-${tenantId}`);
+
+    return reply.send({ id: record.id, key: plainKey, tenantId: record.tenantId });
+  });
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,6 +22,7 @@ import { queueRoutes } from './routes/queue.js';
 import { attachmentRoutes } from './routes/attachments.js';
 import { usageRoutes } from './routes/usage.js';
 import { workspaceRoutes } from './routes/workspace.js';
+import { apiKeyRoutes } from './routes/api-keys.js';
 import { createTelemetryExporter } from './telemetry/exporter.js';
 import { VERSION } from './version.js';
 
@@ -188,6 +189,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
   workspaceRoutes(app, coordinator, dataDir);
   healthRoutes(app, coordinator, pool);
   runnerRoutes(app, coordinator);
+  apiKeyRoutes(app);
 
   coordinator.startLivenessSweep();
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/internal/api-keys` endpoint for the platform to lazily provision per-tenant API keys
- Uses `ASH_INTERNAL_SECRET` bearer token auth (same pattern as runner routes)
- Enables data isolation: each platform tenant gets its own Ash API key scoped to their tenant

## Test plan
- [ ] Verify `POST /api/internal/api-keys` returns `{id, key, tenantId}` with valid internal secret
- [ ] Verify 401 for missing/invalid internal secret
- [ ] Verify 400 for missing tenantId
- [ ] Verify the returned key authenticates and scopes data to the correct tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)