### PR TITLE
release: @ash-ai/server v0.0.18

### DIFF
--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ash-ai/server
 
+## 0.0.18 - 2026-03-01
+
+### Added
+
+- `POST /api/internal/api-keys` endpoint for per-tenant API key provisioning (#48)
+  - Enables the platform to lazily provision isolated API keys per tenant
+  - Uses `ASH_INTERNAL_SECRET` bearer token auth (same pattern as runner routes)
+  - Returns `{id, key, tenantId}` with a freshly generated key
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@ash-ai/server` 0.0.17 → 0.0.18
- CHANGELOG update for per-tenant API key provisioning endpoint (#48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)