### PR TITLE
release: @ash-ai/sandbox v0.0.18

### DIFF
--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.18 - 2026-03-01
+
+### Fixed
+
+- Fix sandbox isolation: hide entire data directory instead of just sandboxes/. Previously, bwrap and gVisor only hid `/data/sandboxes/` with a tmpfs overlay, leaving `/data/agents/` and `/data/sessions/` visible read-only to sandboxed processes.
+
 ## 0.0.15 - 2026-02-28
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump @ash-ai/sandbox 0.0.17 → 0.0.18
- **Security fix**: sandbox isolation now hides entire data directory (`/data/`) instead of just `/data/sandboxes/`, preventing sandboxed processes from reading agents, sessions, and other sandbox metadata

## What changed
Both bwrap (`buildBwrapArgs`) and gVisor (`generateOciSpec`) now use `dirname(sandboxesDir)` to derive the parent data directory and overlay it with tmpfs, then restore only the current sandbox's own directory via bind mount.

CI will create tags, GitHub releases, publish to npm, and build Docker image after merge.