### PR TITLE
release: v0.0.21

### DIFF
--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/sandbox
 
+## 0.0.19 - 2026-03-02
+
+### Fixed
+
+- Fix bridge EACCES on socket creation: add `--dir` for intermediate sandboxes parent directory on bwrap tmpfs overlay, ensuring bind mounts work correctly after data directory isolation change.
+
+### Added
+
+- Agent file persistence via S3: `syncAgentToCloud()` and `restoreAgentFromCloud()` functions for backing up and restoring agent files across ECS redeploys.
+- Export `hasBwrap` from package for use in tests.
+
 ## 0.0.18 - 2026-03-01
 
 ### Fixed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/server
 
+## 0.0.21 - 2026-03-02
+
+### Added
+
+- Auto-restore agent files from S3 when agent directory is missing (survives ECS redeploys). Applied to session create, resume, and fork handlers.
+- Sync agent files to S3 on deploy (fire-and-forget).
+
+### Changed
+
+- Updated dependencies: @ash-ai/sandbox@0.0.19
+
 ## 0.0.18 - 2026-03-01
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- **@ash-ai/sandbox v0.0.19**: Fix bridge EACCES on socket (bwrap --dir fix), agent S3 persistence functions, export hasBwrap
- **@ash-ai/server v0.0.21**: Auto-restore agent files from S3 on session create/resume/fork, sync agent files on deploy

## Test plan
- [x] All 227+ tests passing
- [x] Docker build succeeds
- [ ] Deploy to ECS and verify sessions start correctly
- [ ] Verify agent files persist across redeploys via S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)