### PR TITLE
release: v0.0.22

### DIFF
--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.20 - 2026-03-02
+
+### Fixed
+
+- Fix sandbox /tmp permissions: use per-sandbox tmp directory bind-mounted over /tmp instead of root-owned tmpfs, allowing the sandbox user to write to /tmp (needed for Claude Code's Bash tool).
+
 ## 0.0.19 - 2026-03-02
 
 ### Fixed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.22 - 2026-03-02
+
+### Changed
+
+- Updated dependencies: @ash-ai/sandbox@0.0.20
+
 ## 0.0.21 - 2026-03-02
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- **@ash-ai/sandbox v0.0.20**: Fix sandbox /tmp permissions — use per-sandbox tmp directory instead of root-owned tmpfs
- **@ash-ai/server v0.0.22**: Updated dependencies

## Test plan
- [x] All 228 tests passing
- [ ] Deploy and verify Bash tool works in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)