### PR TITLE
release: @ash-ai/shared v0.0.17, @ash-ai/bridge v0.0.16, @ash-ai/server v0.0.24

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ash-ai/bridge
 
+## 0.0.16 - 2026-03-06
+
+### Added
+
+- OpenTelemetry tracing: `ash.bridge.query`, `ash.agent.turn`, `ash.tool.use`, `ash.agent.thinking`, `ash.agent.text` spans (#55)
+- Distributed trace context propagation via W3C traceparent from coordinator (#55)
+- Token usage and cost attributes on query spans (#55)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17
+
 ## 0.0.15 - 2026-02-28
 
 ### Added

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.16 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17
+
 ## 0.0.15 - 2026-02-28
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.16 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17, @ash-ai/sandbox@0.0.21
+
 ## 0.0.15 - 2026-02-28
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.21 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17
+
 ## 0.0.20 - 2026-03-02
 
 ### Fixed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.16"
+version = "0.0.17"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.17 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17
+
 ## 0.0.16 - 2026-02-28
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/server
 
+## 0.0.24 - 2026-03-06
+
+### Added
+
+- OpenTelemetry tracing on session lifecycle: create, message, pause, stop, resume spans (#55)
+- Trace context injection into bridge protocol for end-to-end distributed traces (#55)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.17
+
 ## 0.0.23
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/shared
 
+## 0.0.17 - 2026-03-06
+
+### Added
+
+- `traceContext` field on `QueryCommand`, `ResumeCommand`, and `ExecCommand` for W3C traceparent propagation (#55)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME` added to `SANDBOX_ENV_ALLOWLIST` (#55)
+
 ## 0.0.16 - 2026-02-28
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
Patch release for OpenTelemetry tracing (#55).

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/shared | 0.0.16 | 0.0.17 |
| @ash-ai/bridge | 0.0.15 | 0.0.16 |
| @ash-ai/server | 0.0.23 | 0.0.24 |
| @ash-ai/sandbox | 0.0.20 | 0.0.21 |
| @ash-ai/cli | 0.0.15 | 0.0.16 |
| @ash-ai/runner | 0.0.15 | 0.0.16 |
| @ash-ai/sdk | 0.0.16 | 0.0.17 |
| @ash-ai/mcp-server | 0.0.12 | 0.0.13 |
| @ash-ai/ui | 0.0.11 | 0.0.12 |
| ash-ai-sdk | 0.0.16 | 0.0.17 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)