### PR TITLE
release: security hardening v0.0.25

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/bridge
 
+## 0.0.17 - 2026-03-06
+
+### Fixed
+
+- Add 10MB buffer size limit on bridge socket to prevent memory exhaustion (#58)
+- Sanitize error messages to strip file paths before sending over socket (#58)
+
 ## 0.0.16 - 2026-03-06
 
 ### Added

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.17 - 2026-03-06
+
+### Fixed
+
+- Set `~/.ash/` directory permissions to 0700 and credential/config files to 0600 (#58)
+
 ## 0.0.16 - 2026-03-06
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ash-ai/mcp-server
 
+## 0.0.14 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
+## 0.0.13 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.12 - 2026-02-28
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/runner
 
+## 0.0.17 - 2026-03-06
+
+### Changed
+
+- Updated fastify to >=5.8.1 (Content-Type validation bypass CVE fix)
+- Updated dependencies: @ash-ai/shared@0.0.18, @ash-ai/sandbox@0.0.22
+
 ## 0.0.16 - 2026-03-06
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ash-ai/sandbox
 
+## 0.0.22 - 2026-03-06
+
+### Fixed
+
+- Fix command injection in gVisor cleanup, disk monitoring, chown, tar operations by replacing `execSync` with `execFileSync` (#58)
+- Fix path traversal via custom sandboxId with regex validation and resolved path check (#58)
+- Fix Unix socket symlink attack on macOS by placing socket inside sandboxDir on all platforms (#58)
+- Kill entire process group on sandbox cleanup instead of just bridge process (#58)
+- Clean up resources (child process, cgroups) on bridge connect failure (#58)
+- Treat `du` timeout as disk limit exceeded to defend against symlink loops (#58)
+
 ## 0.0.21 - 2026-03-06
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.17"
+version = "0.0.18"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.18 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.18
+
 ## 0.0.17 - 2026-03-06
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @ash-ai/server
 
+## 0.0.25 - 2026-03-06
+
+### Fixed
+
+- Remove plaintext API key from server startup stdout — key is saved to file only (#58)
+- Fix path prefix collision in agent file upload with `resolve()` + `path.sep` (#58)
+- Require `ASH_INTERNAL_SECRET` in production and use `timingSafeEqual` for comparison (#58)
+
+### Added
+
+- Add `@fastify/rate-limit` with 100 req/15min global, 20 req/15min on session/agent creation (#58)
+- Add `@fastify/cors` with `ALLOWED_ORIGINS` env var, rejecting cross-origin by default (#58)
+- Add `maxLength` constraints to all string body fields in API schemas (#58)
+- Disable Swagger UI in production (#58)
+- Log HTTPS warning when running in production without TLS (#58)
+
+### Changed
+
+- Updated fastify to >=5.8.1 (Content-Type validation bypass CVE fix)
+- Updated dependencies: @ash-ai/shared@0.0.18
+
 ## 0.0.24 - 2026-03-06
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.18 - 2026-03-06
+
+### Changed
+
+- Add runtime validation to bridge protocol `decode()`: plain object check, discriminator validation, required field checks, and prototype pollution defense (#58)
+
 ## 0.0.17 - 2026-03-06
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ash-ai/ui
 
+## 0.0.13 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
+## 0.0.12 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.11 - 2026-02-28
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG update for security hardening release.

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/shared | 0.0.17 | 0.0.18 |
| @ash-ai/bridge | 0.0.16 | 0.0.17 |
| @ash-ai/sandbox | 0.0.21 | 0.0.22 |
| @ash-ai/server | 0.0.24 | 0.0.25 |
| @ash-ai/cli | 0.0.16 | 0.0.17 |
| @ash-ai/runner | 0.0.16 | 0.0.17 |
| @ash-ai/sdk | 0.0.17 | 0.0.18 |
| @ash-ai/mcp-server | 0.0.13 | 0.0.14 |
| @ash-ai/ui | 0.0.12 | 0.0.13 |

## Test plan
- [x] Version bumps applied via `pnpm release:bump patch`
- [x] CHANGELOGs updated for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)