### PR TITLE
Add agent-level default env vars, replace startupScript with file-based startup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build clean test test-integration test-cli test-restore typecheck bench bench-sandbox bench-sandbox-crdb bench-all \
+.PHONY: install build clean rebuild test test-integration test-cli test-restore typecheck bench bench-sandbox bench-sandbox-crdb bench-all \
        link build-standalone \
        server qa-bot deploy-qa-bot \
        dev dev-no-sandbox kill logs \
@@ -26,6 +26,10 @@ link: build
 # Build standalone binaries (requires bun)
 build-standalone: build
 	./scripts/build-standalone.sh
+
+# Rebuild everything: all packages + Docker image + link CLI globally
+rebuild: build docker-build
+	cd packages/cli && pnpm link --global
 
 clean:
 	pnpm clean

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -75,6 +75,7 @@
 | [features/multi-runner.md](./features/multi-runner.md) | Multi-runner architecture: standalone vs coordinator mode, session routing |
 | [features/metrics.md](./features/metrics.md) | Prometheus `/metrics` endpoint, structured resume log lines, pool stats, cold resume source breakdown |
 | [features/multi-coordinator.md](./features/multi-coordinator.md) | Horizontal control plane: DB-backed runner registry, multi-coordinator with CRDB |
+| [features/agent-env.md](./features/agent-env.md) | Agent-level default environment variables for sessions |
 
 ## Diagrams
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,11 +86,14 @@ Deploy (register) an agent. Upserts — if the name exists, the version incremen
 ```json
 {
   "name": "my-agent",
-  "path": "/absolute/path/to/agent-dir"
+  "path": "/absolute/path/to/agent-dir",
+  "env": { "API_ENDPOINT": "https://api.example.com" }
 }
 ```
 
 The directory at `path` must contain a `CLAUDE.md` file.
+
+Optional `env` sets default environment variables injected into every session's sandbox. See [agent-env.md](./features/agent-env.md) for merge order.
 
 **Response** `201`:
 
@@ -142,11 +145,12 @@ Update an existing agent's metadata.
 {
   "description": "Updated description",
   "model": "claude-sonnet-4-5-20250929",
-  "status": "active"
+  "status": "active",
+  "env": { "API_ENDPOINT": "https://api-v2.example.com" }
 }
 ```
 
-All fields are optional: `name`, `slug`, `description`, `model`, `backend`, `systemPrompt`, `status`, `config`.
+All fields are optional: `name`, `slug`, `description`, `model`, `backend`, `systemPrompt`, `status`, `config`, `env`.
 
 **Response** `200`: `{ "agent": { ... } }`
 
@@ -204,7 +208,6 @@ Create a session. Spawns a sandboxed bridge process for the named agent.
   "model": "claude-sonnet-4-5-20250929",
   "credentialId": "uuid",
   "extraEnv": { "MY_VAR": "value" },
-  "startupScript": "pip install pandas",
   "mcpServers": {
     "my-tools": { "url": "https://my-app.com/mcp/tenant-123" }
   },
@@ -218,6 +221,8 @@ Create a session. Spawns a sandboxed bridge process for the named agent.
 ```
 
 Only `agent` is required — this must be the agent **name** (the `name` field returned by `GET /api/agents`). All other fields are optional.
+
+**Env merge order** (lowest to highest priority): `agent.env` → `credentialId` env → `extraEnv` → `ASH_PERMISSION_MODE`. See [agent-env.md](./features/agent-env.md).
 
 **Response** `201`:
 

--- a/docs/features/agent-env.md
+++ b/docs/features/agent-env.md
@@ -1,0 +1,92 @@
+# Agent-Level Default Environment Variables
+
+## What
+
+Agents can define default environment variables that are automatically injected into every session's sandbox. This eliminates the need to pass the same env vars on every `createSession` call.
+
+## Why
+
+Many agents need consistent environment variables across all sessions — API endpoints, feature flags, configuration values. Without agent-level env, every session creation call must redundantly specify the same `extraEnv`. This feature moves that configuration to the agent definition where it belongs.
+
+## How
+
+### Merge Order
+
+Environment variables are merged with this priority (lowest to highest):
+
+```
+agent.env  →  credential env  →  session extraEnv  →  ASH_PERMISSION_MODE
+```
+
+On conflict, higher-priority values win. For example, if `agent.env` sets `FOO=bar` and session `extraEnv` sets `FOO=baz`, the sandbox gets `FOO=baz`.
+
+### API
+
+#### Deploy with env (POST `/api/agents`)
+
+```bash
+curl -X POST http://localhost:4100/api/agents \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "my-agent",
+    "path": "/path/to/agent",
+    "env": {
+      "API_ENDPOINT": "https://api.example.com",
+      "LOG_LEVEL": "debug"
+    }
+  }'
+```
+
+#### Update env (PATCH `/api/agents/:name`)
+
+```bash
+curl -X PATCH http://localhost:4100/api/agents/my-agent \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "env": {
+      "API_ENDPOINT": "https://api-v2.example.com"
+    }
+  }'
+```
+
+Pass an empty object `{}` to clear all env vars.
+
+#### SDK
+
+```typescript
+// Deploy with env
+await client.deployAgent('my-agent', '/path/to/agent', {
+  env: { API_ENDPOINT: 'https://api.example.com' },
+});
+
+// Update env
+await client.updateAgent('my-agent', {
+  env: { API_ENDPOINT: 'https://api-v2.example.com' },
+});
+
+// Session-level extraEnv overrides agent env on conflict
+await client.createSession('my-agent', {
+  extraEnv: { LOG_LEVEL: 'warn' },  // overrides agent's LOG_LEVEL if set
+});
+```
+
+#### CLI
+
+```bash
+# Deploy with env
+ash deploy ./my-agent -e API_ENDPOINT=https://api.example.com -e LOG_LEVEL=debug
+
+# Session with env override
+ash session create my-agent -e LOG_LEVEL=warn
+```
+
+### Security Considerations
+
+- Env values are stored as **plain text** in the database. Use the credentials API for secrets (API keys, tokens).
+- Agent env is visible in the agent API response. Do not store sensitive values here.
+- The env merge is deterministic: agent < credential < session < permission mode.
+
+## Known Limitations
+
+- Env values are not encrypted. Use `POST /api/credentials` for sensitive keys.
+- Updating agent env does not affect already-running sessions — only new sessions pick up changes.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -869,9 +869,6 @@
                       "type": "string"
                     }
                   },
-                  "startupScript": {
-                    "type": "string"
-                  },
                   "model": {
                     "type": "string",
                     "description": "Model override for this session. Overrides agent .claude/settings.json default."

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -30,8 +30,10 @@ async function request(method: string, path: string, body?: unknown): Promise<Re
   return res;
 }
 
-export async function deployAgent(name: string, path: string) {
-  const res = await request('POST', '/api/agents', { name, path });
+export async function deployAgent(name: string, path: string, env?: Record<string, string>) {
+  const body: Record<string, unknown> = { name, path };
+  if (env) body.env = env;
+  const res = await request('POST', '/api/agents', body);
   return (await res.json() as { agent: unknown }).agent;
 }
 
@@ -45,8 +47,10 @@ export async function getAgentInfo(name: string) {
   return (await res.json() as { agent: unknown }).agent;
 }
 
-export async function createSession(agent: string) {
-  const res = await request('POST', '/api/sessions', { agent });
+export async function createSession(agent: string, extraEnv?: Record<string, string>) {
+  const body: Record<string, unknown> = { agent };
+  if (extraEnv) body.extraEnv = extraEnv;
+  const res = await request('POST', '/api/sessions', body);
   return (await res.json() as { session: unknown }).session;
 }
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -5,14 +5,31 @@ import { ASH_AGENTS_SUBDIR } from '@ash-ai/shared';
 import { deployAgent } from '../client.js';
 import { ashAgentsDir, ensureDataDir } from '../docker.js';
 
+/** Parse repeated -e KEY=VALUE options into a Record. */
+function parseEnvOpts(envPairs?: string[]): Record<string, string> | undefined {
+  if (!envPairs || envPairs.length === 0) return undefined;
+  const env: Record<string, string> = {};
+  for (const pair of envPairs) {
+    const idx = pair.indexOf('=');
+    if (idx === -1) {
+      console.error(`Invalid env format: "${pair}" — expected KEY=VALUE`);
+      process.exit(1);
+    }
+    env[pair.slice(0, idx)] = pair.slice(idx + 1);
+  }
+  return env;
+}
+
 export function deployCommand(): Command {
   return new Command('deploy')
     .description('Deploy an agent to the server')
     .argument('<path>', 'Path to agent directory')
     .option('-n, --name <name>', 'Agent name (defaults to directory name)')
-    .action(async (agentPath: string, opts: { name?: string }) => {
+    .option('-e, --env <KEY=VALUE>', 'Default env var for sessions (repeatable)', (val: string, acc: string[]) => { acc.push(val); return acc; }, [])
+    .action(async (agentPath: string, opts: { name?: string; env?: string[] }) => {
       const absPath = resolve(agentPath);
       const name = opts.name || absPath.split('/').pop()!;
+      const env = parseEnvOpts(opts.env);
 
       // If the path exists locally, copy to ~/.ash/agents/ and use relative path
       // This enables Docker mode where ~/.ash is volume-mounted into the container
@@ -24,7 +41,7 @@ export function deployCommand(): Command {
 
         const relativePath = `${ASH_AGENTS_SUBDIR}/${name}`;
         try {
-          const agent = await deployAgent(name, relativePath);
+          const agent = await deployAgent(name, relativePath, env);
           console.log(`Deployed agent: ${JSON.stringify(agent, null, 2)}`);
         } catch (err: unknown) {
           console.error(`Deploy failed: ${err instanceof Error ? err.message : err}`);
@@ -35,7 +52,7 @@ export function deployCommand(): Command {
 
       // Path doesn't exist locally — assume it's a server-side path (backward compatible)
       try {
-        const agent = await deployAgent(name, absPath);
+        const agent = await deployAgent(name, absPath, env);
         console.log(`Deployed agent: ${JSON.stringify(agent, null, 2)}`);
       } catch (err: unknown) {
         console.error(`Deploy failed: ${err instanceof Error ? err.message : err}`);

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -54,9 +54,22 @@ export function sessionCommand(): Command {
     .command('create')
     .description('Create a new session')
     .argument('<agent>', 'Agent name')
-    .action(async (agent: string) => {
+    .option('-e, --env <KEY=VALUE>', 'Extra env var for this session (repeatable)', (val: string, acc: string[]) => { acc.push(val); return acc; }, [])
+    .action(async (agent: string, opts: { env?: string[] }) => {
       try {
-        const session = await createSession(agent);
+        let extraEnv: Record<string, string> | undefined;
+        if (opts.env && opts.env.length > 0) {
+          extraEnv = {};
+          for (const pair of opts.env) {
+            const idx = pair.indexOf('=');
+            if (idx === -1) {
+              console.error(`Invalid env format: "${pair}" — expected KEY=VALUE`);
+              process.exit(1);
+            }
+            extraEnv[pair.slice(0, idx)] = pair.slice(idx + 1);
+          }
+        }
+        const session = await createSession(agent, extraEnv);
         console.log(`Session created: ${JSON.stringify(session, null, 2)}`);
       } catch (err: unknown) {
         console.error(`Failed: ${err instanceof Error ? err.message : err}`);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -81,6 +81,14 @@ export function startCommand(): Command {
       // Build envPassthrough list from --database-url and --env flags
       const envPassthrough: string[] = [];
 
+      // Pass through sandbox config env vars if set
+      if (process.env.ASH_SANDBOX_BACKEND) {
+        envPassthrough.push('ASH_SANDBOX_BACKEND');
+      }
+      if (process.env.ASH_SANDBOX_MEMORY_MB) {
+        envPassthrough.push('ASH_SANDBOX_MEMORY_MB');
+      }
+
       if (opts.databaseUrl) {
         process.env.ASH_DATABASE_URL = opts.databaseUrl;
         envPassthrough.push('ASH_DATABASE_URL');

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -26,6 +26,11 @@ export function statusCommand(): Command {
           console.log(`  Active sessions:  ${h.activeSessions ?? 'unknown'}`);
           console.log(`  Active sandboxes: ${h.activeSandboxes ?? 'unknown'}`);
           console.log(`  Uptime:           ${h.uptime ?? 'unknown'}s`);
+
+          const pool = h.pool as Record<string, number> | undefined;
+          if (pool) {
+            console.log(`  Pool: ${pool.warm} warm, ${pool.warming} warming, ${pool.cold} cold, ${pool.running} running (max ${pool.maxCapacity})`);
+          }
         } catch {
           console.log('  Health check failed (server may still be starting)');
         }

--- a/packages/runner/src/routes/sandboxes.ts
+++ b/packages/runner/src/routes/sandboxes.ts
@@ -43,7 +43,6 @@ export function sandboxRoutes(app: FastifyInstance, pool: SandboxPool, dataDir: 
       skipAgentCopy?: boolean;
       limits?: Record<string, number>;
       extraEnv?: Record<string, string>;
-      startupScript?: string;
       mcpServers?: Record<string, unknown>;
       systemPrompt?: string;
     };
@@ -57,7 +56,6 @@ export function sandboxRoutes(app: FastifyInstance, pool: SandboxPool, dataDir: 
         skipAgentCopy: body.skipAgentCopy,
         limits: body.limits,
         extraEnv: body.extraEnv,
-        startupScript: body.startupScript,
         mcpServers: body.mcpServers as Record<string, import('@ash-ai/shared').McpServerConfig> | undefined,
         systemPrompt: body.systemPrompt,
       });

--- a/packages/sandbox/src/manager.ts
+++ b/packages/sandbox/src/manager.ts
@@ -37,8 +37,6 @@ export interface CreateSandboxOpts {
   onOomKill?: (sandboxId: string) => void;
   /** Extra env vars to inject into the sandbox (e.g. decrypted credentials). */
   extraEnv?: Record<string, string>;
-  /** Shell script to run in workspace after install.sh but before the bridge starts. */
-  startupScript?: string;
   /** Per-session MCP servers. Merged into the agent's .mcp.json (session overrides agent). */
   mcpServers?: Record<string, McpServerConfig>;
   /** System prompt override. Replaces the agent's CLAUDE.md for this session. */
@@ -228,33 +226,34 @@ export class SandboxManager {
     }
     const installScriptMs = installTimer();
 
-    // Run startup script if provided (only on fresh creation, not resume)
+    // Run startup.sh if present in agent directory (only on fresh creation, not resume)
     const startupTimer = startTimer();
-    if (!opts.skipAgentCopy && opts.startupScript) {
-      const startupPath = join(workspaceDir, 'startup.sh');
-      writeFileSync(startupPath, opts.startupScript, 'utf-8');
-      chmodSync(startupPath, 0o755);
-      console.log(`[sandbox:${shortId}] Running startup.sh...`);
-      this.appendLog(id, 'system', 'Running startup.sh...');
-      try {
-        const startupOutput = execFileSync(startupPath, [], {
-          cwd: workspaceDir,
-          env,
-          timeout: INSTALL_SCRIPT_TIMEOUT_MS,
-          stdio: ['ignore', 'pipe', 'pipe'],
-          ...(sandboxUid !== undefined && { uid: sandboxUid, gid: sandboxGid }),
-        });
-        if (startupOutput.length > 0) {
-          const text = startupOutput.toString().trimEnd();
-          console.log(`[sandbox:${shortId}:startup] ${text}`);
-          this.appendLog(id, 'system', text);
+    if (!opts.skipAgentCopy) {
+      const startupScript = join(workspaceDir, 'startup.sh');
+      if (existsSync(startupScript)) {
+        chmodSync(startupScript, 0o755);
+        console.log(`[sandbox:${shortId}] Running startup.sh...`);
+        this.appendLog(id, 'system', 'Running startup.sh...');
+        try {
+          const startupOutput = execFileSync(startupScript, [], {
+            cwd: workspaceDir,
+            env,
+            timeout: INSTALL_SCRIPT_TIMEOUT_MS,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            ...(sandboxUid !== undefined && { uid: sandboxUid, gid: sandboxGid }),
+          });
+          if (startupOutput.length > 0) {
+            const text = startupOutput.toString().trimEnd();
+            console.log(`[sandbox:${shortId}:startup] ${text}`);
+            this.appendLog(id, 'system', text);
+          }
+          console.log(`[sandbox:${shortId}] startup.sh completed`);
+          this.appendLog(id, 'system', 'startup.sh completed');
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.appendLog(id, 'system', `startup.sh failed: ${msg}`);
+          throw new Error(`startup.sh failed for sandbox ${shortId}: ${msg}`);
         }
-        console.log(`[sandbox:${shortId}] startup.sh completed`);
-        this.appendLog(id, 'system', 'startup.sh completed');
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.appendLog(id, 'system', `startup.sh failed: ${msg}`);
-        throw new Error(`startup.sh failed for sandbox ${shortId}: ${msg}`);
       }
     }
     const startupScriptMs = startupTimer();
@@ -333,8 +332,9 @@ export class SandboxManager {
     let client: BridgeClient;
     let bridgeConnectMs: number;
     try {
-      // Restrict socket permissions to owner only (prevents local user hijacking)
-      chmodSync(socketPath, 0o600);
+      // Restrict socket permissions to owner only (prevents local user hijacking).
+      // chmod on Unix sockets fails with EINVAL on Docker Desktop (macOS VirtioFS) — skip gracefully.
+      try { chmodSync(socketPath, 0o600); } catch {}
       client = new BridgeClient(socketPath);
       await client.connect();
       bridgeConnectMs = bridgeConnectTimer();

--- a/packages/sandbox/src/pool.ts
+++ b/packages/sandbox/src/pool.ts
@@ -209,7 +209,7 @@ export class SandboxPool {
    * Pre-create sandboxes for an agent so first sessions skip install/startup latency.
    * Sandboxes are created with no sessionId and sit in 'warm' state until claimed.
    */
-  async warmUp(agentName: string, agentDir: string, count: number, opts?: { startupScript?: string; extraEnv?: Record<string, string> }): Promise<void> {
+  async warmUp(agentName: string, agentDir: string, count: number, opts?: { extraEnv?: Record<string, string> }): Promise<void> {
     let created = 0;
     for (let i = 0; i < count; i++) {
       // Respect capacity
@@ -223,7 +223,6 @@ export class SandboxPool {
         const sandbox = await this.manager.create({
           agentDir,
           sessionId: '', // placeholder — pre-warm sandboxes have no session
-          startupScript: opts?.startupScript,
           extraEnv: opts?.extraEnv,
         });
 

--- a/packages/sdk-python/ash_sdk/ash_client.py
+++ b/packages/sdk-python/ash_sdk/ash_client.py
@@ -128,7 +128,6 @@ class AshClient:
         *,
         credential_id: str | None = None,
         extra_env: dict[str, str] | None = None,
-        startup_script: str | None = None,
         model: str | None = None,
         system_prompt: str | None = None,
         permission_mode: str | None = None,
@@ -145,7 +144,6 @@ class AshClient:
             agent: Name of the deployed agent.
             credential_id: API credential ID to inject.
             extra_env: Additional environment variables.
-            startup_script: Shell script to run after install.
             model: Model override (e.g. ``claude-sonnet-4-20250514``).
             system_prompt: System prompt override (replaces agent CLAUDE.md).
             permission_mode: Permission mode (``bypassPermissions``, ``permissionsByAgent``, ``default``).
@@ -164,8 +162,6 @@ class AshClient:
             body["credentialId"] = credential_id
         if extra_env is not None:
             body["extraEnv"] = extra_env
-        if startup_script is not None:
-            body["startupScript"] = startup_script
         if model is not None:
             body["model"] = model
         if system_prompt is not None:

--- a/packages/sdk-python/ash_sdk/models/post_api_sessions_body.py
+++ b/packages/sdk-python/ash_sdk/models/post_api_sessions_body.py
@@ -30,7 +30,6 @@ class PostApiSessionsBody:
         agent (str):
         credential_id (str | Unset):
         extra_env (PostApiSessionsBodyExtraEnv | Unset):
-        startup_script (str | Unset):
         model (str | Unset): Model override for this session. Overrides agent .claude/settings.json default.
         mcp_servers (PostApiSessionsBodyMcpServers | Unset): Per-session MCP servers. Merged into agent .mcp.json
             (session overrides agent). Enables sidecar pattern.
@@ -48,7 +47,6 @@ class PostApiSessionsBody:
     agent: str
     credential_id: str | Unset = UNSET
     extra_env: PostApiSessionsBodyExtraEnv | Unset = UNSET
-    startup_script: str | Unset = UNSET
     model: str | Unset = UNSET
     mcp_servers: PostApiSessionsBodyMcpServers | Unset = UNSET
     system_prompt: str | Unset = UNSET
@@ -68,8 +66,6 @@ class PostApiSessionsBody:
         extra_env: dict[str, Any] | Unset = UNSET
         if not isinstance(self.extra_env, Unset):
             extra_env = self.extra_env.to_dict()
-
-        startup_script = self.startup_script
 
         model = self.model
 
@@ -112,8 +108,6 @@ class PostApiSessionsBody:
             field_dict["credentialId"] = credential_id
         if extra_env is not UNSET:
             field_dict["extraEnv"] = extra_env
-        if startup_script is not UNSET:
-            field_dict["startupScript"] = startup_script
         if model is not UNSET:
             field_dict["model"] = model
         if mcp_servers is not UNSET:
@@ -159,8 +153,6 @@ class PostApiSessionsBody:
         else:
             extra_env = PostApiSessionsBodyExtraEnv.from_dict(_extra_env)
 
-        startup_script = d.pop("startupScript", UNSET)
-
         model = d.pop("model", UNSET)
 
         _mcp_servers = d.pop("mcpServers", UNSET)
@@ -198,7 +190,6 @@ class PostApiSessionsBody:
             agent=agent,
             credential_id=credential_id,
             extra_env=extra_env,
-            startup_script=startup_script,
             model=model,
             mcp_servers=mcp_servers,
             system_prompt=system_prompt,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -99,8 +99,10 @@ export class AshClient {
 
   // -- Agents -----------------------------------------------------------------
 
-  async deployAgent(name: string, path: string): Promise<Agent> {
-    const res = await this.request<{ agent: Agent }>('POST', '/api/agents', { name, path });
+  async deployAgent(name: string, path: string, opts?: { env?: Record<string, string> }): Promise<Agent> {
+    const body: Record<string, unknown> = { name, path };
+    if (opts?.env) body.env = opts.env;
+    const res = await this.request<{ agent: Agent }>('POST', '/api/agents', body);
     return res.agent;
   }
 
@@ -160,7 +162,6 @@ export class AshClient {
   async createSession(agent: string, opts?: {
     credentialId?: string;
     extraEnv?: Record<string, string>;
-    startupScript?: string;
     model?: string;
     /** Per-session MCP servers. Merged into agent's .mcp.json (session overrides agent). */
     mcpServers?: Record<string, McpServerConfig>;
@@ -180,7 +181,6 @@ export class AshClient {
     const body: Record<string, unknown> = { agent };
     if (opts?.credentialId) body.credentialId = opts.credentialId;
     if (opts?.extraEnv) body.extraEnv = opts.extraEnv;
-    if (opts?.startupScript) body.startupScript = opts.startupScript;
     if (opts?.model) body.model = opts.model;
     if (opts?.mcpServers) body.mcpServers = opts.mcpServers;
     if (opts?.systemPrompt != null) body.systemPrompt = opts.systemPrompt;

--- a/packages/server/drizzle/pg/0010_steep_masque.sql
+++ b/packages/server/drizzle/pg/0010_steep_masque.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "env" text;

--- a/packages/server/drizzle/pg/meta/0010_snapshot.json
+++ b/packages/server/drizzle/pg/meta/0010_snapshot.json
@@ -1,0 +1,1223 @@
+{
+  "id": "1de53387-76c0-47d5-8f72-48f95a14bb3c",
+  "prevId": "738824aa-492d-4efd-9b2f-b6b940542a89",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_agents_tenant_name": {
+          "name": "idx_agents_tenant_name",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_tenant": {
+          "name": "idx_agents_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_tenant": {
+          "name": "idx_api_keys_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_attachments_session": {
+          "name": "idx_attachments_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachments_message": {
+          "name": "idx_attachments_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_tenant": {
+          "name": "idx_credentials_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_unique_seq": {
+          "name": "idx_messages_unique_seq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_session": {
+          "name": "idx_messages_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.queue_items": {
+      "name": "queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_queue_tenant": {
+          "name": "idx_queue_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_queue_status": {
+          "name": "idx_queue_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners": {
+      "name": "runners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_sandboxes": {
+          "name": "max_sandboxes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active_count": {
+          "name": "active_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "warming_count": {
+          "name": "warming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_runners_heartbeat": {
+          "name": "idx_runners_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandboxes": {
+      "name": "sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warming'"
+        },
+        "workspace_dir": {
+          "name": "workspace_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_state": {
+          "name": "idx_sandboxes_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_session": {
+          "name": "idx_sandboxes_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_last_used": {
+          "name": "idx_sandboxes_last_used",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_tenant": {
+          "name": "idx_sandboxes_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_session_events_unique_seq": {
+          "name": "idx_session_events_unique_seq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_session": {
+          "name": "idx_session_events_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_type": {
+          "name": "idx_session_events_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_tenant": {
+          "name": "idx_sessions_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_runner": {
+          "name": "idx_sessions_runner",
+          "columns": [
+            {
+              "expression": "runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_session": {
+          "name": "idx_usage_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_type": {
+          "name": "idx_usage_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/pg/meta/_journal.json
+++ b/packages/server/drizzle/pg/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772315876730,
       "tag": "0009_white_landau",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1772851318205,
+      "tag": "0010_steep_masque",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0010_wooden_the_anarchist.sql
+++ b/packages/server/drizzle/sqlite/0010_wooden_the_anarchist.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agents` ADD `env` text;

--- a/packages/server/drizzle/sqlite/meta/0010_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0010_snapshot.json
@@ -1,0 +1,1016 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "23aa4123-21f1-48f7-b509-a40cbde8fea8",
+  "prevId": "bc5401b9-71a2-4c47-b12c-f480f3ccf7d7",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_tenant_name": {
+          "name": "idx_agents_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_agents_tenant": {
+          "name": "idx_agents_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_api_keys_tenant": {
+          "name": "idx_api_keys_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attachments_session": {
+          "name": "idx_attachments_session",
+          "columns": [
+            "tenant_id",
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attachments_message": {
+          "name": "idx_attachments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credentials": {
+      "name": "credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_tenant": {
+          "name": "idx_credentials_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_unique_seq": {
+          "name": "idx_messages_unique_seq",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session": {
+          "name": "idx_messages_session",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queue_items": {
+      "name": "queue_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_queue_tenant": {
+          "name": "idx_queue_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_queue_status": {
+          "name": "idx_queue_status",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runners": {
+      "name": "runners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_sandboxes": {
+          "name": "max_sandboxes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "active_count": {
+          "name": "active_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "warming_count": {
+          "name": "warming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_runners_heartbeat": {
+          "name": "idx_runners_heartbeat",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sandboxes": {
+      "name": "sandboxes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'warming'"
+        },
+        "workspace_dir": {
+          "name": "workspace_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_state": {
+          "name": "idx_sandboxes_state",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_session": {
+          "name": "idx_sandboxes_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_last_used": {
+          "name": "idx_sandboxes_last_used",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_tenant": {
+          "name": "idx_sandboxes_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_events": {
+      "name": "session_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_events_unique_seq": {
+          "name": "idx_session_events_unique_seq",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "idx_session_events_session": {
+          "name": "idx_session_events_session",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "idx_session_events_type": {
+          "name": "idx_session_events_type",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_tenant": {
+          "name": "idx_sessions_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_runner": {
+          "name": "idx_sessions_runner",
+          "columns": [
+            "runner_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_events": {
+      "name": "usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_usage_session": {
+          "name": "idx_usage_session",
+          "columns": [
+            "tenant_id",
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            "tenant_id",
+            "agent_name"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_type": {
+          "name": "idx_usage_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772315872320,
       "tag": "0009_nasty_morph",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1772851317613,
+      "tag": "0010_wooden_the_anarchist",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/openapi.json
+++ b/packages/server/openapi.json
@@ -869,9 +869,6 @@
                       "type": "string"
                     }
                   },
-                  "startupScript": {
-                    "type": "string"
-                  },
                   "model": {
                     "type": "string",
                     "description": "Model override for this session. Overrides agent .claude/settings.json default."

--- a/packages/server/src/__tests__/db.test.ts
+++ b/packages/server/src/__tests__/db.test.ts
@@ -8,6 +8,7 @@ import {
   upsertAgent,
   getAgent,
   listAgents,
+  updateAgent,
   deleteAgent,
   insertSession,
   insertForkedSession,
@@ -82,6 +83,66 @@ describe('database', () => {
 
     it('returns false when deleting nonexistent agent', async () => {
       expect(await deleteAgent('ghost')).toBe(false);
+    });
+
+    it('creates agent with env', async () => {
+      const env = { API_KEY: 'secret', DEBUG: 'true' };
+      const agent = await upsertAgent('env-agent', '/tmp/env', undefined, env);
+      expect(agent.env).toEqual(env);
+    });
+
+    it('persists and retrieves env via getAgent', async () => {
+      const env = { FOO: 'bar', BAZ: 'qux' };
+      await upsertAgent('env-agent', '/tmp/env', undefined, env);
+      const agent = await getAgent('env-agent');
+      expect(agent!.env).toEqual(env);
+    });
+
+    it('env is undefined when not provided', async () => {
+      const agent = await upsertAgent('no-env', '/tmp/no-env');
+      expect(agent.env).toBeUndefined();
+
+      const fetched = await getAgent('no-env');
+      expect(fetched!.env).toBeUndefined();
+    });
+
+    it('listAgents returns env', async () => {
+      const env = { KEY: 'value' };
+      await upsertAgent('with-env', '/tmp/with', undefined, env);
+      await upsertAgent('without-env', '/tmp/without');
+      const agents = await listAgents();
+      const withEnv = agents.find(a => a.name === 'with-env')!;
+      const withoutEnv = agents.find(a => a.name === 'without-env')!;
+      expect(withEnv.env).toEqual(env);
+      expect(withoutEnv.env).toBeUndefined();
+    });
+
+    it('upsert updates env on re-deploy', async () => {
+      await upsertAgent('env-agent', '/tmp/v1', undefined, { OLD: 'val' });
+      await upsertAgent('env-agent', '/tmp/v2', undefined, { NEW: 'val' });
+      const agent = await getAgent('env-agent');
+      expect(agent!.env).toEqual({ NEW: 'val' });
+    });
+
+    it('updateAgent updates env', async () => {
+      await upsertAgent('env-agent', '/tmp/env');
+      const updated = await updateAgent('env-agent', { env: { KEY: 'value' } });
+      expect(updated!.env).toEqual({ KEY: 'value' });
+
+      const fetched = await getAgent('env-agent');
+      expect(fetched!.env).toEqual({ KEY: 'value' });
+    });
+
+    it('updateAgent clears env with empty object', async () => {
+      await upsertAgent('env-agent', '/tmp/env', undefined, { KEY: 'value' });
+      await updateAgent('env-agent', { env: {} });
+      const agent = await getAgent('env-agent');
+      expect(agent!.env).toBeUndefined();
+    });
+
+    it('updateAgent returns null for nonexistent agent', async () => {
+      const result = await updateAgent('ghost', { env: { KEY: 'val' } });
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/server/src/__tests__/openapi.test.ts
+++ b/packages/server/src/__tests__/openapi.test.ts
@@ -82,7 +82,7 @@ describe('OpenAPI spec generation', () => {
         if (path[method]) count++;
       }
     }
-    expect(count).toBe(25);
+    expect(count).toBe(26);
   });
 
   it('has component schemas for Agent, Session, ApiError, HealthResponse', () => {

--- a/packages/server/src/__tests__/session-create.test.ts
+++ b/packages/server/src/__tests__/session-create.test.ts
@@ -8,11 +8,14 @@ import { sessionRoutes } from '../routes/sessions.js';
 import { initDb, closeDb, upsertAgent } from '../db/index.js';
 import type { RunnerCoordinator } from '../runner/coordinator.js';
 
-function mockCoordinator(): RunnerCoordinator {
+function mockCoordinator(captureOpts?: { createSandboxOpts?: any[] }): RunnerCoordinator {
   return {
     selectBackend: async () => ({
       backend: {
-        createSandbox: async () => ({ sandboxId: 'sbx-1', workspaceDir: '/tmp/ws' }),
+        createSandbox: async (opts: any) => {
+          if (captureOpts) captureOpts.createSandboxOpts!.push(opts);
+          return { sandboxId: 'sbx-1', workspaceDir: '/tmp/ws' };
+        },
       },
       runnerId: '__local__',
     }),
@@ -90,5 +93,57 @@ describe('POST /api/sessions', () => {
     // but should NOT be 422 or 404
     expect(res.statusCode).not.toBe(422);
     expect(res.statusCode).not.toBe(404);
+  });
+
+  it('passes agent-level env to sandbox creation', async () => {
+    const captured: any[] = [];
+    const agentDir = join(dataDir, 'agents', 'env-agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('env-agent', agentDir, undefined, { AGENT_KEY: 'agent-val' });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator({ createSandboxOpts: captured }), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'env-agent' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].extraEnv).toEqual({ AGENT_KEY: 'agent-val' });
+  });
+
+  it('session-level extraEnv overrides agent-level env', async () => {
+    const captured: any[] = [];
+    const agentDir = join(dataDir, 'agents', 'env-agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('env-agent', agentDir, undefined, { SHARED: 'agent', AGENT_ONLY: 'yes' });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator({ createSandboxOpts: captured }), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'env-agent', extraEnv: { SHARED: 'session', SESSION_ONLY: 'yes' } },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].extraEnv).toEqual({
+      SHARED: 'session',        // session overrides agent
+      AGENT_ONLY: 'yes',        // agent-level preserved
+      SESSION_ONLY: 'yes',      // session-level added
+    });
   });
 });

--- a/packages/server/src/db/drizzle-db.ts
+++ b/packages/server/src/db/drizzle-db.ts
@@ -15,6 +15,12 @@ function parseConfig(raw: string | null | undefined): SessionConfig | null {
   try { return JSON.parse(raw); } catch { return null; }
 }
 
+/** Parse JSON env column. Returns undefined on null/invalid. */
+function parseEnv(raw: string | null | undefined): Record<string, string> | undefined {
+  if (!raw) return undefined;
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
 /**
  * Unified Db implementation backed by Drizzle ORM.
  * Works with both SQLite (better-sqlite3) and PostgreSQL (pg) drivers.
@@ -131,9 +137,10 @@ export class DrizzleDb implements Db {
 
   // -- Agents -----------------------------------------------------------------
 
-  async upsertAgent(name: string, path: string, tenantId: string = 'default'): Promise<Agent> {
+  async upsertAgent(name: string, path: string, tenantId: string = 'default', env?: Record<string, string>): Promise<Agent> {
     const { agents } = this.schema;
     const now = new Date().toISOString();
+    const envJson = env ? JSON.stringify(env) : null;
 
     // Check for existing agent to get id and version
     const existing = await this.drizzle
@@ -145,15 +152,18 @@ export class DrizzleDb implements Db {
     const version = existing.length > 0 ? existing[0].version + 1 : 1;
     const id = existing.length > 0 ? existing[0].id : randomUUID();
 
+    const set: Record<string, unknown> = { version, path, updatedAt: now };
+    if (env !== undefined) set.env = envJson;
+
     await this.drizzle
       .insert(agents)
-      .values({ id, tenantId, name, version, path, createdAt: now, updatedAt: now })
+      .values({ id, tenantId, name, version, path, env: envJson, createdAt: now, updatedAt: now })
       .onConflictDoUpdate({
         target: [agents.tenantId, agents.name],
-        set: { version, path, updatedAt: now },
+        set,
       });
 
-    return { id, name, tenantId, version, path, createdAt: now, updatedAt: now };
+    return { id, name, tenantId, version, path, createdAt: now, updatedAt: now, ...(env && { env }) };
   }
 
   async getAgent(name: string, tenantId: string = 'default'): Promise<Agent | null> {
@@ -165,7 +175,8 @@ export class DrizzleDb implements Db {
       .limit(1);
     if (rows.length === 0) return null;
     const r = rows[0];
-    return { id: r.id, name: r.name, tenantId: r.tenantId, version: r.version, path: r.path, createdAt: r.createdAt, updatedAt: r.updatedAt };
+    const env = parseEnv(r.env);
+    return { id: r.id, name: r.name, tenantId: r.tenantId, version: r.version, path: r.path, createdAt: r.createdAt, updatedAt: r.updatedAt, ...(env && { env }) };
   }
 
   async listAgents(tenantId: string = 'default'): Promise<Agent[]> {
@@ -175,7 +186,26 @@ export class DrizzleDb implements Db {
       .from(agents)
       .where(eq(agents.tenantId, tenantId))
       .orderBy(asc(agents.name));
-    return rows.map((r: any) => ({ id: r.id, name: r.name, tenantId: r.tenantId, version: r.version, path: r.path, createdAt: r.createdAt, updatedAt: r.updatedAt }));
+    return rows.map((r: any) => {
+      const env = parseEnv(r.env);
+      return { id: r.id, name: r.name, tenantId: r.tenantId, version: r.version, path: r.path, createdAt: r.createdAt, updatedAt: r.updatedAt, ...(env && { env }) };
+    });
+  }
+
+  async updateAgent(name: string, updates: { env?: Record<string, string> }, tenantId: string = 'default'): Promise<Agent | null> {
+    const { agents } = this.schema;
+    const now = new Date().toISOString();
+    const set: Record<string, unknown> = { updatedAt: now };
+    if (updates.env !== undefined) {
+      set.env = Object.keys(updates.env).length > 0 ? JSON.stringify(updates.env) : null;
+    }
+
+    await this.drizzle
+      .update(agents)
+      .set(set)
+      .where(and(eq(agents.tenantId, tenantId), eq(agents.name, name)));
+
+    return this.getAgent(name, tenantId);
   }
 
   async deleteAgent(name: string, tenantId: string = 'default'): Promise<boolean> {

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -28,9 +28,10 @@ export interface Db {
   deleteRunner(id: string): Promise<void>;
   listAllRunners(): Promise<RunnerRecord[]>;
   // Agents (tenant-scoped)
-  upsertAgent(name: string, path: string, tenantId?: string): Promise<Agent>;
+  upsertAgent(name: string, path: string, tenantId?: string, env?: Record<string, string>): Promise<Agent>;
   getAgent(name: string, tenantId?: string): Promise<Agent | null>;
   listAgents(tenantId?: string): Promise<Agent[]>;
+  updateAgent(name: string, updates: { env?: Record<string, string> }, tenantId?: string): Promise<Agent | null>;
   deleteAgent(name: string, tenantId?: string): Promise<boolean>;
   // Sessions (tenant-scoped)
   insertSession(id: string, agentName: string, sandboxId: string, tenantId?: string, parentSessionId?: string, model?: string, config?: SessionConfig | null): Promise<Session>;
@@ -159,8 +160,8 @@ export async function initDb(opts: { dataDir: string; databaseUrl?: string }): P
 // -- Async re-exports (preserve call-site compatibility) ----------------------
 // Optional tenantId defaults to 'default' for single-tenant/dev mode.
 
-export async function upsertAgent(name: string, path: string, tenantId?: string): Promise<Agent> {
-  return getDb().upsertAgent(name, path, tenantId);
+export async function upsertAgent(name: string, path: string, tenantId?: string, env?: Record<string, string>): Promise<Agent> {
+  return getDb().upsertAgent(name, path, tenantId, env);
 }
 
 export async function getAgent(name: string, tenantId?: string): Promise<Agent | null> {
@@ -169,6 +170,10 @@ export async function getAgent(name: string, tenantId?: string): Promise<Agent |
 
 export async function listAgents(tenantId?: string): Promise<Agent[]> {
   return getDb().listAgents(tenantId);
+}
+
+export async function updateAgent(name: string, updates: { env?: Record<string, string> }, tenantId?: string): Promise<Agent | null> {
+  return getDb().updateAgent(name, updates, tenantId);
 }
 
 export async function deleteAgent(name: string, tenantId?: string): Promise<boolean> {

--- a/packages/server/src/db/schema.pg.ts
+++ b/packages/server/src/db/schema.pg.ts
@@ -19,6 +19,7 @@ export const agents = pgTable('agents', {
   name: text('name').notNull(),
   version: integer('version').notNull().default(1),
   path: text('path').notNull(),
+  env: text('env'),  // JSON blob of default env vars for sessions
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -19,6 +19,7 @@ export const agents = sqliteTable('agents', {
   name: text('name').notNull(),
   version: integer('version').notNull().default(1),
   path: text('path').notNull(),
+  env: text('env'),  // JSON blob of default env vars for sessions
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { existsSync, readdirSync, statSync, readFileSync, createReadStream, mkdirSync, writeFileSync } from 'node:fs';
 import { join, isAbsolute, relative, basename, extname, dirname, resolve, sep } from 'node:path';
-import { upsertAgent, getAgent, listAgents, deleteAgent } from '../db/index.js';
+import { upsertAgent, getAgent, listAgents, updateAgent, deleteAgent } from '../db/index.js';
 import type { FileEntry } from '@ash-ai/shared';
 import type { SandboxPool } from '@ash-ai/sandbox';
 import { syncAgentToCloud } from '@ash-ai/sandbox';
@@ -81,6 +81,7 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
               required: ['path', 'content'],
             },
           },
+          env: { type: 'object', additionalProperties: { type: 'string' }, description: 'Default environment variables injected into every session sandbox' },
         },
         required: ['name'],
       },
@@ -94,11 +95,12 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
       },
     },
   }, async (req, reply) => {
-    const { name, path: inputPath, systemPrompt, files } = req.body as {
+    const { name, path: inputPath, systemPrompt, files, env } = req.body as {
       name: string;
       path?: string;
       systemPrompt?: string;
       files?: Array<{ path: string; content: string }>;
+      env?: Record<string, string>;
     };
 
     let resolvedPath: string;
@@ -143,7 +145,7 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
       }
     }
 
-    const agent = await upsertAgent(name, resolvedPath, req.tenantId);
+    const agent = await upsertAgent(name, resolvedPath, req.tenantId, env);
 
     // Best-effort backup to cloud storage (non-blocking)
     syncAgentToCloud(name, resolvedPath, req.tenantId).catch((err) =>
@@ -153,9 +155,7 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
     // Trigger pre-warming if agent has preWarmCount configured
     const preWarmCount = (agent.config as Record<string, unknown> | undefined)?.preWarmCount;
     if (pool && typeof preWarmCount === 'number' && preWarmCount > 0) {
-      pool.warmUp(agent.name, agent.path, preWarmCount, {
-        startupScript: (agent.config as Record<string, unknown> | undefined)?.startupScript as string | undefined,
-      }).catch((err) =>
+      pool.warmUp(agent.name, agent.path, preWarmCount).catch((err) =>
         console.error(`[server] Pre-warm failed for ${agent.name}:`, err)
       );
     }
@@ -224,6 +224,38 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
       return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
     }
     return reply.send({ ok: true });
+  });
+
+  // Update agent
+  app.patch<{ Params: { name: string } }>('/api/agents/:name', {
+    schema: {
+      tags: ['agents'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        properties: {
+          env: { type: 'object', additionalProperties: { type: 'string' }, description: 'Default environment variables injected into every session sandbox' },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: { agent: { $ref: 'Agent#' } },
+          required: ['agent'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const { env } = req.body as { env?: Record<string, string> };
+
+    const existing = await getAgent(req.params.name, req.tenantId);
+    if (!existing) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const agent = await updateAgent(req.params.name, { env }, req.tenantId);
+    return reply.send({ agent });
   });
 
   // List files in agent directory

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -87,7 +87,6 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
           agent: { type: 'string', minLength: 1, maxLength: 255 },
           credentialId: { type: 'string', maxLength: 255 },
           extraEnv: { type: 'object', additionalProperties: { type: 'string' } },
-          startupScript: { type: 'string', maxLength: 100_000 },
           model: { type: 'string', maxLength: 100, description: 'Model override for this session. Overrides agent .claude/settings.json default.' },
           mcpServers: {
             type: 'object',
@@ -122,7 +121,7 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
       },
     },
   }, async (req, reply) => {
-    const { agent, credentialId, extraEnv: bodyExtraEnv, startupScript, model, mcpServers, systemPrompt, permissionMode, allowedTools, disallowedTools, betas, subagents, initialAgent } = req.body as { agent: string; credentialId?: string; extraEnv?: Record<string, string>; startupScript?: string; model?: string; mcpServers?: Record<string, { url?: string; command?: string; args?: string[]; env?: Record<string, string> }>; systemPrompt?: string; permissionMode?: string; allowedTools?: string[]; disallowedTools?: string[]; betas?: string[]; subagents?: Record<string, unknown>; initialAgent?: string };
+    const { agent, credentialId, extraEnv: bodyExtraEnv, model, mcpServers, systemPrompt, permissionMode, allowedTools, disallowedTools, betas, subagents, initialAgent } = req.body as { agent: string; credentialId?: string; extraEnv?: Record<string, string>; model?: string; mcpServers?: Record<string, { url?: string; command?: string; args?: string[]; env?: Record<string, string> }>; systemPrompt?: string; permissionMode?: string; allowedTools?: string[]; disallowedTools?: string[]; betas?: string[]; subagents?: Record<string, unknown>; initialAgent?: string };
 
     return tracer.startActiveSpan('ash.session.create', { attributes: { 'ash.agent.name': agent } }, async (span) => {
     try {
@@ -142,8 +141,15 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
       console.log(`[sessions] Restored agent "${agent}" from cloud storage`);
     }
 
-    // Resolve credential to env vars if provided
+    // Build extraEnv with merge order: agent.env → credential env → session extraEnv → ASH_PERMISSION_MODE
     let extraEnv: Record<string, string> | undefined;
+
+    // 1. Agent-level default env (lowest priority)
+    if (agentRecord.env) {
+      extraEnv = { ...agentRecord.env };
+    }
+
+    // 2. Credential env overrides agent defaults
     if (credentialId) {
       const cred = await decryptCredential(credentialId, req.tenantId);
       if (!cred) {
@@ -151,16 +157,16 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
         return reply.status(400).send({ error: 'Invalid or inaccessible credential', statusCode: 400 });
       }
       const envKey = cred.type === 'anthropic' ? 'ANTHROPIC_API_KEY' : cred.type === 'openai' ? 'OPENAI_API_KEY' : 'ASH_CUSTOM_API_KEY';
-      extraEnv = { [envKey]: cred.key };
+      extraEnv = { ...extraEnv, [envKey]: cred.key };
       touchCredentialUsed(credentialId).catch(() => {});
     }
 
-    // Merge body-level extraEnv (overrides credential env on conflict)
+    // 3. Session-level extraEnv overrides everything above
     if (bodyExtraEnv) {
       extraEnv = { ...extraEnv, ...bodyExtraEnv };
     }
 
-    // Inject permission mode into sandbox env (bridge reads ASH_PERMISSION_MODE)
+    // 4. Permission mode always wins (highest priority)
     if (permissionMode) {
       extraEnv = { ...extraEnv, ASH_PERMISSION_MODE: permissionMode };
     }
@@ -180,7 +186,6 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
         agentName: agentRecord.name,
         sandboxId: sessionId,
         extraEnv,
-        startupScript,
         mcpServers,
         systemPrompt,
         onOomKill: () => {

--- a/packages/server/src/runner/local-backend.ts
+++ b/packages/server/src/runner/local-backend.ts
@@ -23,7 +23,6 @@ export class LocalRunnerBackend implements RunnerBackend {
       limits: opts.limits,
       onOomKill: opts.onOomKill,
       extraEnv: opts.extraEnv,
-      startupScript: opts.startupScript,
       mcpServers: opts.mcpServers,
       systemPrompt: opts.systemPrompt,
     });

--- a/packages/server/src/runner/remote-backend.ts
+++ b/packages/server/src/runner/remote-backend.ts
@@ -24,7 +24,6 @@ export class RemoteRunnerBackend implements RunnerBackend {
       skipAgentCopy: opts.skipAgentCopy,
       limits: opts.limits as Record<string, number> | undefined,
       extraEnv: opts.extraEnv,
-      startupScript: opts.startupScript,
       mcpServers: opts.mcpServers,
       systemPrompt: opts.systemPrompt,
     });

--- a/packages/server/src/runner/runner-client.ts
+++ b/packages/server/src/runner/runner-client.ts
@@ -36,7 +36,6 @@ export class RunnerClient {
     skipAgentCopy?: boolean;
     limits?: Record<string, number>;
     extraEnv?: Record<string, string>;
-    startupScript?: string;
     mcpServers?: Record<string, unknown>;
     systemPrompt?: string;
   }): Promise<{ sandboxId: string; workspaceDir: string }> {

--- a/packages/server/src/runner/types.ts
+++ b/packages/server/src/runner/types.ts
@@ -11,8 +11,6 @@ export interface CreateSandboxRequest {
   onOomKill?: (sandboxId: string) => void;
   /** Extra env vars to inject into the sandbox (e.g. decrypted credentials). */
   extraEnv?: Record<string, string>;
-  /** Shell script to run in workspace after install.sh but before the bridge starts. */
-  startupScript?: string;
   /** Per-session MCP servers. Merged into agent's .mcp.json (session overrides agent). */
   mcpServers?: Record<string, McpServerConfig>;
   /** System prompt override. Replaces agent's CLAUDE.md for this session. */

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -12,6 +12,7 @@ const AgentSchema = {
     tenantId: { type: 'string' },
     version: { type: 'integer' },
     path: { type: 'string' },
+    env: { type: 'object', additionalProperties: { type: 'string' } },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
   },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -107,9 +107,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
       for (const agent of agents) {
         const preWarmCount = (agent.config as Record<string, unknown> | undefined)?.preWarmCount;
         if (typeof preWarmCount === 'number' && preWarmCount > 0 && agent.path) {
-          await pool!.warmUp(agent.name, agent.path, preWarmCount, {
-            startupScript: (agent.config as Record<string, unknown> | undefined)?.startupScript as string | undefined,
-          });
+          await pool!.warmUp(agent.name, agent.path, preWarmCount);
         }
       }
     }).catch((err) => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,9 +12,10 @@ export const BRIDGE_READY_TIMEOUT_MS = 10_000;
 // Agent setup
 export const INSTALL_SCRIPT_TIMEOUT_MS = 120_000; // 2 min
 
-// Resource limits
+// Resource limits (ASH_SANDBOX_MEMORY_MB overrides default memory limit)
+const envMemoryMb = parseInt(process.env.ASH_SANDBOX_MEMORY_MB || '', 10);
 export const DEFAULT_SANDBOX_LIMITS = {
-  memoryMb: 2048,
+  memoryMb: envMemoryMb > 0 ? envMemoryMb : 2048,
   cpuPercent: 100,
   diskMb: 1024,
   maxProcesses: 64,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -27,6 +27,8 @@ export interface Agent {
   status?: 'active' | 'inactive' | 'archived';
   /** Arbitrary config blob. */
   config?: Record<string, unknown>;
+  /** Default environment variables injected into every session's sandbox. */
+  env?: Record<string, string>;
 }
 
 /** Fields that can be updated on an existing agent via PATCH. */
@@ -39,6 +41,7 @@ export interface AgentUpdate {
   systemPrompt?: string | null;
   status?: 'active' | 'inactive' | 'archived';
   config?: Record<string, unknown>;
+  env?: Record<string, string>;
 }
 
 // -- Sessions -----------------------------------------------------------------
@@ -573,8 +576,6 @@ export interface CreateSessionRequest {
   credentialId?: string;
   /** Extra env vars to inject into the sandbox (merged with credential env). */
   extraEnv?: Record<string, string>;
-  /** Shell script to run in workspace after install.sh but before the bridge starts. */
-  startupScript?: string;
   /** Model override for this session. Overrides agent's .claude/settings.json default. */
   model?: string;
   /**

--- a/skills/ash/references/api-reference.md
+++ b/skills/ash/references/api-reference.md
@@ -74,7 +74,6 @@ interface Agent {
 createSession(agent: string, opts?: {
   credentialId?: string;
   extraEnv?: Record<string, string>;
-  startupScript?: string;
 }): Promise<Session>
 
 listSessions(agent?: string): Promise<Session[]>

--- a/skills/ash/references/sessions.md
+++ b/skills/ash/references/sessions.md
@@ -26,11 +26,10 @@ starting --> active --> paused --> active (resume)
 **TypeScript:**
 ```typescript
 const session = await client.createSession('my-agent');
-// Optional: pass credential, extra env, startup script
+// Optional: pass credential, extra env
 const session = await client.createSession('my-agent', {
   credentialId: 'cred-id',
   extraEnv: { MY_VAR: 'value' },
-  startupScript: 'npm install',
 });
 ```
 

--- a/website/docs/api/sessions.md
+++ b/website/docs/api/sessions.md
@@ -62,7 +62,6 @@ Creates a new session for the specified agent. The server allocates a sandbox, c
 | `systemPrompt` | string | No | System prompt override. Replaces the agent's `CLAUDE.md` for this session only. |
 | `credentialId` | string | No | Credential ID to inject into sandbox env. |
 | `extraEnv` | object | No | Extra env vars to inject into the sandbox (merged with credential env). |
-| `startupScript` | string | No | Shell script to run in workspace after install.sh but before the bridge starts. |
 
 ### Response
 

--- a/website/static/openapi.json
+++ b/website/static/openapi.json
@@ -869,9 +869,6 @@
                       "type": "string"
                     }
                   },
-                  "startupScript": {
-                    "type": "string"
-                  },
                   "model": {
                     "type": "string",
                     "description": "Model override for this session. Overrides agent .claude/settings.json default."


### PR DESCRIPTION
## Summary
- Adds `env` field to agents for default environment variables injected into every session's sandbox
- New PATCH `/api/agents/:name` endpoint to update agent env after deployment
- CLI support: `ash deploy -e KEY=VALUE` and `ash session create -e KEY=VALUE` (repeatable)
- Session env merge order: `agent.env` → credential env → session `extraEnv` → `ASH_PERMISSION_MODE`
- Replaces `startupScript` API field with auto-detection of `startup.sh` in the agent directory
- Configurable sandbox memory via `ASH_SANDBOX_MEMORY_MB` env var
- Graceful chmod fallback for Unix sockets on Docker Desktop (VirtioFS)

## Test plan
- [ ] `pnpm test` passes (db.test.ts, session-create.test.ts, openapi.test.ts updated)
- [ ] Deploy agent with `-e` flags, verify env vars appear in session sandbox
- [ ] PATCH agent env, create session, verify updated env
- [ ] Agent with `startup.sh` file runs it on session create
- [ ] Session without startup.sh skips startup phase cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)