### PR TITLE
release: @ash-ai/sandbox v0.0.25, @ash-ai/cli v0.0.20, @ash-ai/server v0.0.28

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.19 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.18 - 2026-03-06
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @ash-ai/cli
 
+## 0.0.20 - 2026-03-06
+
+### Added
+
+- `ash link` / `ash unlink` commands replacing `ash connect` / `ash disconnect` (#64)
+- Agent file upload via API — `ash deploy` now uploads files instead of copying to shared filesystem (#64)
+- `.env` and `.env.local` file support in agent directories during deploy (#64)
+- Agent name normalization (invalid chars replaced with hyphens) (#64)
+- API key bootstrap recovery in `ash rebuild` (#64)
+
+### Changed
+
+- `ash login` now prints `ash link` hint after successful authentication (#64)
+- Simplified `getServerUrl()` and `getApiKey()` — removed credentials.json fallback (#64)
+- Updated dependencies: dotenv (#64)
+
+### Removed
+
+- `ash connect` / `ash disconnect` commands (replaced by `ash link` / `ash unlink`) (#64)
+
 ## 0.0.19 - 2026-03-06
 
 ### Removed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.16 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.15 - 2026-03-06
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.19 - 2026-03-06
+
+### Changed
+
+- Updated dependencies: @ash-ai/sandbox@0.0.25, @ash-ai/server@0.0.28
+
 ## 0.0.18 - 2026-03-06
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/sandbox
 
+## 0.0.25 - 2026-03-06
+
+### Added
+
+- `SandboxPool.drainAll()` for graceful shutdown with session state persistence (#64)
+- Auto-replenish warm pool after claiming a pre-warmed sandbox (#64)
+
 ## 0.0.24 - 2026-03-06
 
 ### Removed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.20 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.19 - 2026-03-06
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.19"
+version = "0.0.20"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.20 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.19 - 2026-03-06
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @ash-ai/server
 
+## 0.0.28 - 2026-03-06
+
+### Added
+
+- `bulkPauseActiveSessions()` DB method — safety net for ungraceful shutdown (#64)
+- Startup orphan recovery: pauses any sessions left in active/starting state (#64)
+- API key recovery: regenerates bootstrap file when CLI has lost access (#64)
+
+### Changed
+
+- Agent API responses now redact env values (returns `***` instead of secrets) (#64)
+- Default pre-warm count is 1 for all agents (previously required explicit config) (#64)
+- Graceful shutdown uses `pool.drainAll()` instead of `pool.destroyAll()` (#64)
+- `.DS_Store` files skipped in file listing and upload (#64)
+- Updated dependencies: @ash-ai/sandbox@0.0.25
+
+### Fixed
+
+- `PATCH /api/agents/:name` now returns 404 when agent not found (#64)
+
 ## 0.0.27 - 2026-03-06
 
 ### Changed

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.20 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.19 - 2026-03-06
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.15 - 2026-03-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.14 - 2026-03-06
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release for CLI deploy overhaul, link/unlink rename, and server lifecycle hardening (#64).

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/shared | 0.0.19 | 0.0.20 |
| @ash-ai/bridge | 0.0.18 | 0.0.19 |
| @ash-ai/cli | 0.0.19 | **0.0.20** |
| @ash-ai/sandbox | 0.0.24 | **0.0.25** |
| @ash-ai/server | 0.0.27 | **0.0.28** |
| @ash-ai/runner | 0.0.18 | 0.0.19 |
| @ash-ai/sdk | 0.0.19 | 0.0.20 |
| @ash-ai/mcp-server | 0.0.15 | 0.0.16 |
| @ash-ai/ui | 0.0.14 | 0.0.15 |
| ash-ai-sdk | 0.0.19 | 0.0.20 |

**Bold** = packages with real changes. Others are dependency bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)