### PR TITLE
Pass agent env to pool warmUp, fix CLI version, improve status display

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -29,7 +29,13 @@ export function statusCommand(): Command {
 
           const pool = h.pool as Record<string, number> | undefined;
           if (pool) {
-            console.log(`  Pool: ${pool.warm} warm, ${pool.warming} warming, ${pool.cold} cold, ${pool.running} running (max ${pool.maxCapacity})`);
+            const parts = [];
+            if (pool.running)  parts.push(`${pool.running} running`);
+            if (pool.waiting)  parts.push(`${pool.waiting} waiting`);
+            if (pool.warm)     parts.push(`${pool.warm} warm`);
+            if (pool.warming)  parts.push(`${pool.warming} warming`);
+            if (pool.cold)     parts.push(`${pool.cold} cold`);
+            console.log(`  Pool: ${parts.join(', ')} (max ${pool.maxCapacity})`);
           }
         } catch {
           console.log('  Health check failed (server may still be starting)');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { basename } from 'node:path';
+import { basename, dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { deployCommand } from './commands/deploy.js';
 import { sessionCommand } from './commands/session.js';
@@ -24,7 +26,7 @@ export const isDevMode =
 const program = new Command()
   .name(isDevMode ? 'ash-dev' : 'ash')
   .description(isDevMode ? 'Agent orchestration CLI (dev mode — uses local Docker build)' : 'Agent orchestration CLI')
-  .version('0.1.0');
+  .version(JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf-8')).version);
 
 program.addCommand(startCommand());
 program.addCommand(stopCommand());

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -171,7 +171,7 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
     const preWarmCount = (agent.config as Record<string, unknown> | undefined)?.preWarmCount;
     const warmCount = typeof preWarmCount === 'number' ? preWarmCount : 1;
     if (pool && warmCount > 0) {
-      pool.warmUp(agent.name, agent.path, warmCount).catch((err) =>
+      pool.warmUp(agent.name, agent.path, warmCount, agent.env ? { extraEnv: agent.env } : undefined).catch((err) =>
         console.error(`[server] Pre-warm failed for ${agent.name}:`, err)
       );
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -116,7 +116,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
         const preWarmCount = (agent.config as Record<string, unknown> | undefined)?.preWarmCount;
         const warmCount = typeof preWarmCount === 'number' ? preWarmCount : 1;
         if (warmCount > 0 && agent.path) {
-          await pool!.warmUp(agent.name, agent.path, warmCount);
+          await pool!.warmUp(agent.name, agent.path, warmCount, agent.env ? { extraEnv: agent.env } : undefined);
         }
       }
     }).catch((err) => {


### PR DESCRIPTION
## Summary
- Forward `agent.env` as `extraEnv` when pre-warming sandboxes so warmed instances get the correct environment variables from agent config
- Read CLI version from `package.json` instead of hardcoded `'0.1.0'`
- Show only non-zero pool counts in `ash status` and add `waiting` state

## Test plan
- [ ] Verify `ash status` shows correct pool counts
- [ ] Verify `ash --version` shows actual package version
- [ ] Verify pre-warmed sandboxes receive agent env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)