### PR TITLE
release: @ash-ai/cli v0.0.21, @ash-ai/server v0.0.29

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/cli
 
+## 0.0.21 - 2026-03-07
+
+### Fixed
+
+- `ash --version` now reads version from package.json instead of hardcoded '0.1.0' (#66)
+- `ash status` pool display only shows non-zero counts and includes waiting state (#66)
+
 ## 0.0.20 - 2026-03-06
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.29 - 2026-03-07
+
+### Fixed
+
+- Pre-warmed sandboxes now receive agent environment variables via `extraEnv` (#66)
+
 ## 0.0.28 - 2026-03-06
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release for cli and server packages.

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/cli | 0.0.20 | 0.0.21 |
| @ash-ai/server | 0.0.28 | 0.0.29 |

### @ash-ai/cli v0.0.21
- `ash --version` now reads version from package.json instead of hardcoded '0.1.0'
- `ash status` pool display only shows non-zero counts and includes waiting state

### @ash-ai/server v0.0.29
- Pre-warmed sandboxes now receive agent environment variables via `extraEnv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)