### PR TITLE
release: @ash-ai/server v0.0.30

### DIFF
--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.30 - 2026-03-07
+
+### Changed
+
+- Bump global rate limit from 100 to 1500 requests per 15 minutes (hosted multi-tenant traffic shares a single IP)
+
 ## 0.0.29 - 2026-03-07
 
 ### Fixed

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump global rate limit from 100 to 1500 requests per 15 minutes
- Hosted multi-tenant traffic from Vercel shares a single IP to the NLB, exhausting the old 100-req budget quickly

## Release
```
Package              Version
@ash-ai/server       0.0.29 -> 0.0.30
```

CI will create tags, GitHub releases, publish to npm, and build Docker image after merge.