### PR TITLE
Add dashboard, Bedrock credentials, and SDK improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY packages/server/package.json packages/server/tsconfig.json packages/server/
 COPY packages/cli/package.json packages/cli/tsconfig.json packages/cli/
 COPY packages/runner/package.json packages/runner/tsconfig.json packages/runner/
 COPY packages/sdk/package.json packages/sdk/tsconfig.json packages/sdk/
+COPY packages/ui/package.json packages/ui/tsconfig.json packages/ui/tsup.config.ts packages/ui/
+COPY packages/dashboard/package.json packages/dashboard/tsconfig.json packages/dashboard/
 
 # Install dependencies (cached unless package.json or lockfile changes)
 RUN pnpm install --frozen-lockfile
@@ -39,6 +41,15 @@ COPY packages/server/drizzle/ packages/server/drizzle/
 COPY packages/cli/src/ packages/cli/src/
 COPY packages/runner/src/ packages/runner/src/
 COPY packages/sdk/src/ packages/sdk/src/
+
+COPY packages/ui/src/ packages/ui/src/
+COPY packages/ui/postcss.config.js packages/ui/tailwind.config.ts packages/ui/
+
+# Dashboard: copy source + config (Next.js static export)
+COPY packages/dashboard/app/ packages/dashboard/app/
+COPY packages/dashboard/components/ packages/dashboard/components/
+COPY packages/dashboard/lib/ packages/dashboard/lib/
+COPY packages/dashboard/next.config.ts packages/dashboard/postcss.config.mjs packages/dashboard/
 
 # Build
 RUN pnpm build

--- a/Makefile
+++ b/Makefile
@@ -78,40 +78,46 @@ qa-bot:
 
 # Deploy the qa-bot agent to a running Ash server, then start the web UI
 deploy-qa-bot:
-	npx tsx packages/cli/src/index.ts deploy ./examples/qa-bot/agent --name qa-bot
+	npx tsx packages/cli/src/index.ts deploy ./examples/personal-assistant-demo/agent_folder --name personal-assistant-demo
 
-# Start Ash server in Docker, deploy qa-bot agent, then start QA Bot UI
+# Start Ash server in Docker, deploy qa-bot agent, then start QA Bot UI + Dashboard
 dev: docker-build
-	@echo "Starting Ash server (Docker) + QA Bot UI..."
+	@echo "Starting Ash server (Docker) + QA Bot UI + Dashboard..."
 	@echo ""
 	npx tsx packages/cli/src/index.ts start --image ash-dev --no-pull
 	@echo ""
 	@echo "Deploying qa-bot agent..."
-	npx tsx packages/cli/src/index.ts deploy ./examples/qa-bot/agent --name qa-bot
+	npx tsx packages/cli/src/index.ts deploy ./examples/personal-assistant-demo/agent_folder --name personal-assistant-demo
 	@echo ""
 	@echo "  Ash server  → http://localhost:4100 (Docker)"
+	@echo "  Dashboard   → http://localhost:4100/dashboard/ (served by Docker)"
+	@echo "  Dashboard   → http://localhost:4200/dashboard/ (Next.js dev, hot-reload)"
 	@echo "  QA Bot UI   → http://localhost:3100"
 	@echo ""
 	@trap 'npx tsx packages/cli/src/index.ts stop 2>/dev/null; kill 0' EXIT; \
+	pnpm --filter '@ash-ai/dashboard' dev & \
 	pnpm --filter qa-bot dev & \
 	wait
 
-# Start both server + qa-bot natively (no Docker, no sandbox)
+# Start server + qa-bot + dashboard natively (no Docker, no sandbox)
 dev-no-sandbox:
-	@echo "Starting Ash server + QA Bot UI (native, no sandbox)..."
+	@echo "Starting Ash server + QA Bot UI + Dashboard (native, no sandbox)..."
 	@echo "  Ash server  → http://localhost:4100"
+	@echo "  Dashboard   → http://localhost:4200/dashboard/ (Next.js dev, hot-reload)"
 	@echo "  QA Bot UI   → http://localhost:3100"
 	@echo ""
 	@trap 'kill 0' EXIT; \
 	ASH_REAL_SDK=1 pnpm --filter '@ash-ai/server' dev & \
+	pnpm --filter '@ash-ai/dashboard' dev & \
 	sleep 2 && pnpm --filter qa-bot dev & \
 	wait
 
-# Kill processes on dev ports (4100, 3100) and stop Docker container
+# Kill processes on dev ports (4100, 4200, 3100) and stop Docker container
 kill:
-	@echo "Killing processes on ports 4100 and 3100..."
+	@echo "Killing processes on ports 4100, 4200, and 3100..."
 	@-npx tsx packages/cli/src/index.ts stop 2>/dev/null; true
 	@-lsof -ti :4100 | xargs kill 2>/dev/null; true
+	@-lsof -ti :4200 | xargs kill 2>/dev/null; true
 	@-lsof -ti :3100 | xargs kill 2>/dev/null; true
 	@echo "Done."
 

--- a/examples/personal-assistant-demo/app/page.tsx
+++ b/examples/personal-assistant-demo/app/page.tsx
@@ -382,8 +382,8 @@ export default function Chat() {
                 } disabled:opacity-50`}
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-mono text-zinc-400 truncate">
-                    {s.id.slice(0, 8)}
+                  <span className="text-xs font-mono text-zinc-400 break-all">
+                    {s.id}
                   </span>
                   <div className="flex items-center gap-1.5">
                     <span className={`inline-block w-1.5 h-1.5 rounded-full ${
@@ -424,7 +424,7 @@ export default function Chat() {
             <h1 className="text-lg font-semibold">Personal Assistant</h1>
             {sessionId && (
               <span className="text-xs font-mono text-zinc-500">
-                {sessionId.slice(0, 8)}
+                {sessionId}
               </span>
             )}
           </div>

--- a/packages/dashboard/app/agents/page.tsx
+++ b/packages/dashboard/app/agents/page.tsx
@@ -1,0 +1,408 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+import { useAgents } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge, StatusBadge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import {
+  Bot,
+  Code2,
+  Copy,
+  MoreVertical,
+  Plus,
+  Terminal,
+  Trash2,
+  Upload,
+  X,
+} from 'lucide-react'
+import Link from 'next/link'
+import type { Agent } from '@ash-ai/shared'
+
+export default function AgentsPage() {
+  const { agents, loading, refetch } = useAgents()
+  const [showCreate, setShowCreate] = useState(false)
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete(name: string) {
+    setError(null)
+    try {
+      await getClient().deleteAgent(name)
+      setDeleteConfirm(null)
+      refetch()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to delete agent'
+      setError(message)
+      setDeleteConfirm(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Agents</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Deploy and manage your AI agents
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Agent
+        </Button>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={160} />
+          ))}
+        </div>
+      ) : agents.length === 0 ? (
+        <EmptyState
+          icon={<Bot className="h-12 w-12" />}
+          title="No agents yet"
+          description="Create your first agent to get started. You can upload files or deploy from the CLI."
+          action={
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Create Agent
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {agents.map((agent) => (
+            <AgentCard
+              key={agent.id || agent.name}
+              agent={agent}
+              onDelete={() => setDeleteConfirm(agent.name)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Create Modal */}
+      {showCreate && (
+        <CreateAgentModal
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false)
+            refetch()
+          }}
+        />
+      )}
+
+      {/* Delete Confirmation */}
+      {deleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <Card className="w-full max-w-md">
+            <CardContent>
+              <h3 className="text-lg font-semibold text-white mb-2">Delete Agent</h3>
+              <p className="text-sm text-white/60 mb-6">
+                Are you sure you want to delete <span className="text-white font-medium">{deleteConfirm}</span>?
+                This action cannot be undone.
+              </p>
+              <div className="flex justify-end gap-3">
+                <Button variant="ghost" onClick={() => setDeleteConfirm(null)}>
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={() => handleDelete(deleteConfirm)}>
+                  Delete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Agent Card ───
+
+function AgentCard({
+  agent,
+  onDelete,
+}: {
+  agent: Agent
+  onDelete: () => void
+}) {
+  const [showMenu, setShowMenu] = useState(false)
+
+  return (
+    <Card className="relative group">
+      <CardContent>
+        <div className="flex items-start justify-between">
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold text-white truncate">
+              {agent.name}
+            </h3>
+            {agent.description && (
+              <p className="text-xs text-white/40 mt-1 line-clamp-2">
+                {agent.description}
+              </p>
+            )}
+          </div>
+          <div className="relative">
+            <button
+              onClick={() => setShowMenu(!showMenu)}
+              className="p-1 text-white/30 hover:text-white/70 transition-colors rounded"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </button>
+            {showMenu && (
+              <>
+                <div className="fixed inset-0" onClick={() => setShowMenu(false)} />
+                <div className="absolute right-0 mt-1 w-40 rounded-lg border border-white/10 bg-[#1c2129] shadow-xl z-10 py-1">
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(agent.name)
+                      setShowMenu(false)
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    <Copy className="h-3.5 w-3.5" /> Copy Name
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowMenu(false)
+                      onDelete()
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" /> Delete
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 mt-3">
+          {agent.model && <Badge variant="info">{agent.model}</Badge>}
+          {agent.status && <StatusBadge status={agent.status} />}
+        </div>
+
+        <div className="flex items-center justify-between mt-4 pt-3 border-t border-white/5">
+          <span className="text-xs text-white/30">
+            {agent.createdAt ? formatRelativeTime(agent.createdAt) : 'Unknown'}
+          </span>
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/playground?agent=${agent.slug || agent.name}`}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-500/10 text-indigo-400 hover:bg-indigo-500/20 transition-colors"
+            >
+              <Code2 className="h-3 w-3" />
+              Try
+            </Link>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Create Agent Modal ───
+
+function CreateAgentModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [tab, setTab] = useState<'upload' | 'cli'>('upload')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [systemPrompt, setSystemPrompt] = useState('')
+  const [files, setFiles] = useState<Array<{ path: string; content: string }>>([])
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleFileSelect = useCallback(async (fileList: FileList) => {
+    const newFiles: Array<{ path: string; content: string }> = []
+    const skipPrefixes = ['node_modules/', '.git/', '__pycache__/', '.venv/', '.DS_Store']
+
+    for (const file of Array.from(fileList)) {
+      const path = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name
+      if (skipPrefixes.some((p) => path.includes(p))) continue
+
+      const text = await file.text()
+      newFiles.push({ path, content: text })
+    }
+    setFiles(newFiles)
+  }, [])
+
+  async function handleCreate() {
+    if (!name.trim()) {
+      setError('Agent name is required')
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+
+    try {
+      await getClient().createAgent(name.trim(), {
+        systemPrompt: systemPrompt || undefined,
+        files: files.length > 0 ? files : undefined,
+      })
+      onCreated()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to create agent'
+      setError(message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-auto">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">Create Agent</h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex gap-1 p-1 bg-white/5 rounded-lg mb-6">
+            <button
+              onClick={() => setTab('upload')}
+              className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                tab === 'upload'
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/50 hover:text-white'
+              }`}
+            >
+              <Upload className="h-4 w-4" /> Upload
+            </button>
+            <button
+              onClick={() => setTab('cli')}
+              className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                tab === 'cli'
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/50 hover:text-white'
+              }`}
+            >
+              <Terminal className="h-4 w-4" /> CLI
+            </button>
+          </div>
+
+          {tab === 'upload' ? (
+            <div className="space-y-4">
+              <Input
+                label="Name"
+                placeholder="my-agent"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium text-white/70">
+                  System Prompt (optional)
+                </label>
+                <textarea
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  rows={3}
+                  placeholder="You are a helpful assistant..."
+                  className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+                />
+              </div>
+
+              {/* File upload zone */}
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium text-white/70">
+                  Agent Files (optional)
+                </label>
+                <div
+                  onClick={() => fileInputRef.current?.click()}
+                  onDragOver={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    if (e.dataTransfer.files.length > 0) {
+                      handleFileSelect(e.dataTransfer.files)
+                    }
+                  }}
+                  className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-white/10 py-8 cursor-pointer hover:border-white/20 hover:bg-white/[0.02] transition-colors"
+                >
+                  <Upload className="h-8 w-8 text-white/20 mb-2" />
+                  <p className="text-sm text-white/40">
+                    Drop files or click to upload
+                  </p>
+                  <p className="text-xs text-white/20 mt-1">
+                    CLAUDE.md, tools, and agent source files
+                  </p>
+                </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  className="hidden"
+                  onChange={(e) => {
+                    if (e.target.files) handleFileSelect(e.target.files)
+                  }}
+                />
+                {files.length > 0 && (
+                  <p className="text-xs text-white/50">
+                    {files.length} file{files.length !== 1 ? 's' : ''} selected
+                  </p>
+                )}
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-400">{error}</p>
+              )}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <Button variant="ghost" onClick={onClose}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreate} disabled={creating}>
+                  {creating ? 'Creating...' : 'Create Agent'}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-white/60">
+                Deploy an agent from your local machine using the Ash CLI:
+              </p>
+              <div className="rounded-lg bg-black/30 p-4 font-mono text-sm text-white/80">
+                <div className="text-white/40 mb-2"># Install the CLI</div>
+                <div>npm install -g @ash-ai/cli</div>
+                <div className="text-white/40 mt-4 mb-2"># Deploy an agent</div>
+                <div>ash deploy ./my-agent --name my-agent</div>
+              </div>
+              <div className="flex justify-end pt-2">
+                <Button variant="ghost" onClick={onClose}>
+                  Close
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/dashboard/app/analytics/page.tsx
+++ b/packages/dashboard/app/analytics/page.tsx
@@ -1,0 +1,226 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAgents, useSessions } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatNumber, formatDuration } from '@/lib/utils'
+import { Activity, Clock, Cpu, Zap } from 'lucide-react'
+
+type Period = '7d' | '30d' | '90d'
+
+function getAfterDate(period: Period): string {
+  const now = new Date()
+  const days = period === '7d' ? 7 : period === '30d' ? 30 : 90
+  now.setDate(now.getDate() - days)
+  return now.toISOString()
+}
+
+interface AgentStats {
+  name: string
+  sessions: number
+  inputTokens: number
+  outputTokens: number
+  toolCalls: number
+  computeSeconds: number
+}
+
+export default function AnalyticsPage() {
+  const [period, setPeriod] = useState<Period>('7d')
+  const { agents } = useAgents()
+  const { sessions } = useSessions({ autoRefresh: false })
+  const [agentStats, setAgentStats] = useState<AgentStats[]>([])
+  const [loading, setLoading] = useState(true)
+  const [totals, setTotals] = useState({
+    sessions: 0,
+    tokens: 0,
+    toolCalls: 0,
+    computeSeconds: 0,
+  })
+
+  useEffect(() => {
+    async function fetchStats() {
+      setLoading(true)
+      const after = getAfterDate(period)
+      const client = getClient()
+
+      try {
+        // Get overall stats
+        const overall = await client.getUsageStats({}).catch(() => null)
+        if (overall) {
+          setTotals({
+            sessions: sessions.length,
+            tokens: (overall.totalInputTokens || 0) + (overall.totalOutputTokens || 0),
+            toolCalls: overall.totalToolCalls || 0,
+            computeSeconds: overall.totalComputeSeconds || 0,
+          })
+        }
+
+        // Get per-agent stats
+        const stats: AgentStats[] = []
+        for (const agent of agents.slice(0, 10)) {
+          try {
+            const s = await client.getUsageStats({
+              agentName: agent.name,
+            })
+            const agentSessions = sessions.filter(
+              (sess) => sess.agentName === agent.name
+            )
+            stats.push({
+              name: agent.name,
+              sessions: agentSessions.length,
+              inputTokens: s?.totalInputTokens || 0,
+              outputTokens: s?.totalOutputTokens || 0,
+              toolCalls: s?.totalToolCalls || 0,
+              computeSeconds: s?.totalComputeSeconds || 0,
+            })
+          } catch {
+            stats.push({
+              name: agent.name,
+              sessions: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              toolCalls: 0,
+              computeSeconds: 0,
+            })
+          }
+        }
+
+        stats.sort((a, b) => b.sessions - a.sessions)
+        setAgentStats(stats)
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (agents.length > 0) {
+      fetchStats()
+    } else {
+      setLoading(false)
+    }
+  }, [period, agents, sessions])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Analytics</h1>
+          <p className="mt-1 text-sm text-white/50">Usage and performance metrics</p>
+        </div>
+        <div className="flex gap-1 p-1 bg-white/5 rounded-lg">
+          {(['7d', '30d', '90d'] as Period[]).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                period === p
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/40 hover:text-white/70'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryCard
+          icon={<Activity className="h-5 w-5" />}
+          label="Sessions"
+          value={loading ? '-' : totals.sessions.toString()}
+        />
+        <SummaryCard
+          icon={<Zap className="h-5 w-5" />}
+          label="Total Tokens"
+          value={loading ? '-' : formatNumber(totals.tokens)}
+        />
+        <SummaryCard
+          icon={<Cpu className="h-5 w-5" />}
+          label="Tool Calls"
+          value={loading ? '-' : formatNumber(totals.toolCalls)}
+        />
+        <SummaryCard
+          icon={<Clock className="h-5 w-5" />}
+          label="Compute Time"
+          value={loading ? '-' : formatDuration(totals.computeSeconds)}
+        />
+      </div>
+
+      {/* Top agents table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Top Agents</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-4 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={40} />
+              ))}
+            </div>
+          ) : agentStats.length === 0 ? (
+            <p className="text-sm text-white/40 text-center py-8">
+              No usage data for this period
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Agent</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Sessions</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Tokens</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Tool Calls</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Compute</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {agentStats.map((stat) => (
+                  <tr key={stat.name} className="hover:bg-white/[0.02]">
+                    <td className="px-6 py-3 text-white/80 font-medium">{stat.name}</td>
+                    <td className="px-6 py-3 text-right text-white/60">{stat.sessions}</td>
+                    <td className="px-6 py-3 text-right text-white/60">
+                      {formatNumber(stat.inputTokens + stat.outputTokens)}
+                    </td>
+                    <td className="px-6 py-3 text-right text-white/60">{stat.toolCalls}</td>
+                    <td className="px-6 py-3 text-right text-white/60">
+                      {formatDuration(stat.computeSeconds)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SummaryCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+}) {
+  return (
+    <Card>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-white/50">{label}</p>
+            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+          </div>
+          <div className="text-white/20">{icon}</div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/dashboard/app/globals.css
+++ b/packages/dashboard/app/globals.css
@@ -1,0 +1,33 @@
+@import "tailwindcss";
+
+@theme {
+  --color-surface: #161b22;
+  --color-surface-dark: #0d1117;
+  --color-surface-elevated: #1c2129;
+  --color-accent: #6366f1;
+  --color-accent-500: #818cf8;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Scrollbar styling */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import Script from 'next/script'
+import './globals.css'
+import { DashboardNav } from '@/components/nav'
+import { AshProvider } from '@/components/providers'
+
+export const metadata: Metadata = {
+  title: 'Ash Dashboard',
+  description: 'Manage agents, sessions, and monitor your Ash server',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en" className="dark">
+      <head>
+        {/* Injects window.__ASH_CONFIG__ with API key + server version.
+            beforeInteractive ensures it loads before React hydration. */}
+        <Script src="/dashboard/config.js" strategy="beforeInteractive" />
+      </head>
+      <body className="bg-[#0d1117] text-zinc-100 antialiased">
+        <AshProvider>
+          <div className="flex min-h-screen">
+            <DashboardNav />
+            <main className="min-w-0 flex-1 pl-64 overflow-y-auto overflow-x-hidden">
+              <div className="mx-auto max-w-[1600px] px-6 pb-6 pt-8 sm:px-8 sm:pb-8 sm:pt-10">
+                {children}
+              </div>
+            </main>
+          </div>
+        </AshProvider>
+      </body>
+    </html>
+  )
+}

--- a/packages/dashboard/app/logs/page.tsx
+++ b/packages/dashboard/app/logs/page.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useAgents, useSessions } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge, StatusBadge } from '@/components/ui/badge'
+import { Select } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { cn, formatRelativeTime, truncateId } from '@/lib/utils'
+import { ChevronDown, ChevronRight, Download, RefreshCw, Search } from 'lucide-react'
+import type { Session, SessionEvent } from '@ash-ai/shared'
+
+export default function LogsPage() {
+  const { agents } = useAgents()
+  const [agentFilter, setAgentFilter] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+  const [search, setSearch] = useState('')
+  const [autoRefresh, setAutoRefresh] = useState(true)
+
+  const { sessions, loading, refetch } = useSessions({
+    agent: agentFilter || undefined,
+    autoRefresh,
+  })
+
+  const filtered = sessions.filter((s) => {
+    if (statusFilter && s.status !== statusFilter) return false
+    if (search) {
+      const q = search.toLowerCase()
+      return (
+        s.id.toLowerCase().includes(q) ||
+        s.agentName.toLowerCase().includes(q) ||
+        s.status.toLowerCase().includes(q)
+      )
+    }
+    return true
+  })
+
+  function exportCSV() {
+    const rows = [
+      ['Session ID', 'Agent', 'Status', 'Created'].join(','),
+      ...filtered.map((s) =>
+        [s.id, s.agentName, s.status, s.createdAt].join(',')
+      ),
+    ]
+    const blob = new Blob([rows.join('\n')], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'sessions.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function exportJSON() {
+    const blob = new Blob([JSON.stringify(filtered, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'sessions.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Logs</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Session activity and event explorer
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={exportCSV}>
+            <Download className="h-4 w-4 mr-1" /> CSV
+          </Button>
+          <Button variant="ghost" size="sm" onClick={exportJSON}>
+            <Download className="h-4 w-4 mr-1" /> JSON
+          </Button>
+          <Button
+            variant={autoRefresh ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setAutoRefresh(!autoRefresh)}
+          >
+            <RefreshCw className={cn('h-4 w-4', autoRefresh && 'animate-spin')} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-3">
+        <div className="flex-1 relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/30" />
+          <input
+            type="text"
+            placeholder="Search sessions..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full h-9 pl-9 pr-3 rounded-xl border bg-white/5 border-white/10 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50"
+          />
+        </div>
+        <Select
+          options={[
+            { value: '', label: 'All Agents' },
+            ...agents.map((a) => ({ value: a.name, label: a.name })),
+          ]}
+          value={agentFilter}
+          onChange={(e) => setAgentFilter(e.target.value)}
+          className="w-40 h-9 text-xs"
+        />
+        <Select
+          options={[
+            { value: '', label: 'All Statuses' },
+            { value: 'active', label: 'Active' },
+            { value: 'paused', label: 'Paused' },
+            { value: 'ended', label: 'Ended' },
+            { value: 'error', label: 'Error' },
+          ]}
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="w-36 h-9 text-xs"
+        />
+      </div>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-4 space-y-2">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <ShimmerBlock key={i} height={40} />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-white/40 text-center py-12">
+              No sessions found
+            </p>
+          ) : (
+            <div className="divide-y divide-white/5">
+              {filtered.map((session) => (
+                <SessionRow key={session.id} session={session} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SessionRow({ session }: { session: Session }) {
+  const [expanded, setExpanded] = useState(false)
+  const [events, setEvents] = useState<SessionEvent[]>([])
+  const [loadingEvents, setLoadingEvents] = useState(false)
+
+  async function toggleExpand() {
+    if (!expanded && events.length === 0) {
+      setLoadingEvents(true)
+      try {
+        const result = await getClient().listSessionEvents(session.id, { limit: 50 })
+        setEvents(result)
+      } catch {
+        // ignore
+      } finally {
+        setLoadingEvents(false)
+      }
+    }
+    setExpanded(!expanded)
+  }
+
+  return (
+    <div>
+      <button
+        onClick={toggleExpand}
+        aria-expanded={expanded}
+        className="flex items-center gap-4 w-full px-4 py-3 text-sm hover:bg-white/[0.02] transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-white/30 shrink-0" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-white/30 shrink-0" />
+        )}
+        <span className="text-xs text-white/30 w-24">
+          {formatRelativeTime(session.createdAt)}
+        </span>
+        <span className="text-xs font-mono text-white/50 w-20">
+          {truncateId(session.id)}
+        </span>
+        <span className="text-sm text-white/70 flex-1 text-left truncate">
+          {session.agentName}
+        </span>
+        <StatusBadge status={session.status} />
+      </button>
+      {expanded && (
+        <div className="pl-12 pr-4 pb-4">
+          {loadingEvents ? (
+            <div className="space-y-1">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={24} />
+              ))}
+            </div>
+          ) : events.length === 0 ? (
+            <p className="text-xs text-white/30 py-2">No events</p>
+          ) : (
+            <div className="space-y-0.5 max-h-64 overflow-auto scrollbar-thin">
+              {events.map((e, i) => {
+                let summary = ''
+                try {
+                  const data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
+                  summary = data?.text?.slice(0, 80) || data?.name || data?.error?.slice(0, 80) || ''
+                } catch {
+                  // ignore
+                }
+                return (
+                  <div key={e.id || i} className="flex items-center gap-3 text-xs py-1">
+                    <span className="text-white/20 font-mono w-6">#{e.sequence}</span>
+                    <Badge>{e.type}</Badge>
+                    <span className="text-white/40 truncate">{summary}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useAgents } from '@/lib/hooks'
+import { useSessions } from '@/lib/hooks'
+import { useHealth } from '@/lib/hooks'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { StatusBadge } from '@/components/ui/badge'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import { Activity, Bot, Cpu, Zap } from 'lucide-react'
+import Link from 'next/link'
+
+export default function DashboardHome() {
+  const { agents, loading: agentsLoading } = useAgents()
+  const { sessions, loading: sessionsLoading } = useSessions({ limit: 5 })
+  const { health } = useHealth()
+
+  const activeSessions = sessions.filter((s) => s.status === 'active')
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Dashboard</h1>
+        <p className="mt-1 text-sm text-white/50">
+          Overview of your Ash server
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<Bot className="h-5 w-5" />}
+          label="Agents"
+          value={agentsLoading ? '-' : agents.length.toString()}
+          href="/agents"
+        />
+        <StatCard
+          icon={<Activity className="h-5 w-5" />}
+          label="Active Sessions"
+          value={sessionsLoading ? '-' : activeSessions.length.toString()}
+          href="/sessions"
+        />
+        <StatCard
+          icon={<Zap className="h-5 w-5" />}
+          label="Total Sessions"
+          value={sessionsLoading ? '-' : sessions.length.toString()}
+          href="/sessions"
+        />
+        <StatCard
+          icon={<Cpu className="h-5 w-5" />}
+          label="Sandboxes"
+          value={health?.activeSandboxes?.toString() ?? '-'}
+        />
+      </div>
+
+      {/* Recent Sessions */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Recent Sessions</CardTitle>
+            <Link
+              href="/sessions"
+              className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              View all
+            </Link>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {sessionsLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={48} />
+              ))}
+            </div>
+          ) : sessions.length === 0 ? (
+            <p className="text-sm text-white/40 py-8 text-center">
+              No sessions yet. Create an agent and start a session in the Playground.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {sessions.slice(0, 5).map((session) => (
+                <Link
+                  key={session.id}
+                  href={`/sessions?id=${session.id}`}
+                  className="flex items-center justify-between rounded-lg border border-white/5 bg-white/[0.02] px-4 py-3 hover:bg-white/5 transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-white truncate">
+                        {session.agentName}
+                      </p>
+                      <p className="text-xs text-white/40 font-mono">
+                        {session.id.slice(0, 8)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <StatusBadge status={session.status} />
+                    <span className="text-xs text-white/30">
+                      {formatRelativeTime(session.createdAt)}
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  href,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  href?: string
+}) {
+  const content = (
+    <Card className={href ? 'hover:border-white/20 cursor-pointer' : ''}>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-white/50">{label}</p>
+            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+          </div>
+          <div className="text-white/20">{icon}</div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+  if (href) return <Link href={href}>{content}</Link>
+  return content
+}

--- a/packages/dashboard/app/playground/page.tsx
+++ b/packages/dashboard/app/playground/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { getClient } from '@/lib/client'
+
+// Dynamic import to avoid SSR issues with @ash-ai/ui
+import dynamic from 'next/dynamic'
+
+const Playground = dynamic(
+  () => import('@ash-ai/ui').then((mod) => ({ default: mod.Playground })),
+  { ssr: false, loading: () => <PlaygroundSkeleton /> }
+)
+
+function PlaygroundSkeleton() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-sm text-white/40">Loading playground...</div>
+    </div>
+  )
+}
+
+function PlaygroundInner() {
+  const searchParams = useSearchParams()
+  const initialAgent = searchParams.get('agent') || undefined
+  const client = getClient()
+
+  return (
+    <div className="h-[calc(100vh-5rem)]">
+      <Playground
+        client={client}
+        {...(initialAgent ? { initialAgent } : {})}
+      />
+    </div>
+  )
+}
+
+export default function PlaygroundPage() {
+  return (
+    <Suspense fallback={<PlaygroundSkeleton />}>
+      <PlaygroundInner />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/queue/page.tsx
+++ b/packages/dashboard/app/queue/page.tsx
@@ -1,0 +1,295 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useAgents } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { cn, formatRelativeTime, truncateId } from '@/lib/utils'
+import { ListOrdered, Plus, RefreshCw, X, XCircle } from 'lucide-react'
+import type { Agent, QueueItem, QueueItemStatus } from '@ash-ai/shared'
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+  processing: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+  completed: 'bg-green-500/20 text-green-400 border-green-500/30',
+  failed: 'bg-red-500/20 text-red-400 border-red-500/30',
+  cancelled: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30',
+}
+
+interface QueueStats {
+  pending: number
+  processing: number
+  completed: number
+  failed: number
+  cancelled: number
+}
+
+export default function QueuePage() {
+  const { agents } = useAgents()
+  const [items, setItems] = useState<QueueItem[]>([])
+  const [stats, setStats] = useState<QueueStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [statusFilter, setStatusFilter] = useState('')
+  const [showEnqueue, setShowEnqueue] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const client = getClient()
+      const [itemsResult, statsResult] = await Promise.all([
+        client.listQueueItems(statusFilter ? { status: statusFilter as QueueItemStatus } : {}),
+        client.getQueueStats(),
+      ])
+      setItems(itemsResult)
+      setStats(statsResult as QueueStats)
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter])
+
+  useEffect(() => {
+    fetchData()
+    const interval = setInterval(fetchData, 5000)
+    return () => clearInterval(interval)
+  }, [fetchData])
+
+  async function handleCancel(id: string) {
+    setError(null)
+    try {
+      await getClient().cancelQueueItem(id)
+      fetchData()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to cancel job'
+      setError(message)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Queue</h1>
+          <p className="mt-1 text-sm text-white/50">Async job queue for agent tasks</p>
+        </div>
+        <Button onClick={() => setShowEnqueue(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Enqueue Job
+        </Button>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+          {(['pending', 'processing', 'completed', 'failed', 'cancelled'] as const).map(
+            (status) => (
+              <Card key={status}>
+                <CardContent className="py-3">
+                  <p className="text-xs text-white/40 capitalize">{status}</p>
+                  <p className="text-xl font-bold text-white">{stats[status]}</p>
+                </CardContent>
+              </Card>
+            )
+          )}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex gap-3">
+        <Select
+          options={[
+            { value: '', label: 'All Statuses' },
+            { value: 'pending', label: 'Pending' },
+            { value: 'processing', label: 'Processing' },
+            { value: 'completed', label: 'Completed' },
+            { value: 'failed', label: 'Failed' },
+          ]}
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="w-40"
+        />
+      </div>
+
+      {/* Items */}
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-4 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={48} />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <EmptyState
+              icon={<ListOrdered className="h-12 w-12" />}
+              title="Queue is empty"
+              description="Enqueue a job to process it asynchronously."
+              action={
+                <Button onClick={() => setShowEnqueue(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Enqueue Job
+                </Button>
+              }
+            />
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">ID</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Agent</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Prompt</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Status</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Age</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {items.map((item) => (
+                  <tr key={item.id} className="hover:bg-white/[0.02]">
+                    <td className="px-6 py-3 font-mono text-xs text-white/50">
+                      {truncateId(item.id)}
+                    </td>
+                    <td className="px-6 py-3 text-white/80">{item.agentName}</td>
+                    <td className="px-6 py-3 text-white/60 max-w-xs truncate">
+                      {item.prompt}
+                    </td>
+                    <td className="px-6 py-3">
+                      <span
+                        className={cn(
+                          'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium border',
+                          STATUS_COLORS[item.status] || STATUS_COLORS.pending
+                        )}
+                      >
+                        {item.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-white/40 text-xs">
+                      {formatRelativeTime(item.createdAt)}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      {item.status === 'pending' && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleCancel(item.id)}
+                          className="text-red-400"
+                        >
+                          <XCircle className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {showEnqueue && (
+        <EnqueueModal
+          agents={agents}
+          onClose={() => setShowEnqueue(false)}
+          onCreated={() => {
+            setShowEnqueue(false)
+            fetchData()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function EnqueueModal({
+  agents,
+  onClose,
+  onCreated,
+}: {
+  agents: Agent[]
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [agentName, setAgentName] = useState(agents[0]?.name || '')
+  const [prompt, setPrompt] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleEnqueue() {
+    if (!agentName || !prompt.trim()) {
+      setError('Agent and prompt are required')
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+
+    try {
+      await getClient().enqueue(agentName, prompt.trim())
+      onCreated()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to enqueue'
+      setError(message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-md">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">Enqueue Job</h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <Select
+              label="Agent"
+              options={agents.map((a) => ({ value: a.name, label: a.name }))}
+              value={agentName}
+              onChange={(e) => setAgentName(e.target.value)}
+            />
+
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-white/70">Prompt</label>
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={4}
+                placeholder="What should the agent do?"
+                className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+              />
+            </div>
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleEnqueue} disabled={creating}>
+                {creating ? 'Enqueuing...' : 'Enqueue'}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -1,0 +1,529 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { useAgents, useSessions } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge, StatusBadge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Select } from '@/components/ui/select'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { cn, formatRelativeTime, truncateId } from '@/lib/utils'
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Download,
+  FileText,
+  MessageSquare,
+  Pause,
+  Play,
+  Square,
+  Terminal,
+} from 'lucide-react'
+import type { Session, Message, SessionEvent } from '@ash-ai/shared'
+
+export default function SessionsPage() {
+  return (
+    <Suspense fallback={<div className="text-sm text-white/40">Loading...</div>}>
+      <SessionsPageInner />
+    </Suspense>
+  )
+}
+
+function SessionsPageInner() {
+  const searchParams = useSearchParams()
+  const initialId = searchParams.get('id')
+
+  const { agents } = useAgents()
+  const [agentFilter, setAgentFilter] = useState<string>('')
+  const [statusFilter, setStatusFilter] = useState<string>('')
+  const { sessions, loading, refetch } = useSessions({
+    agent: agentFilter || undefined,
+    autoRefresh: true,
+  })
+  const [selectedId, setSelectedId] = useState<string | null>(initialId)
+
+  // Auto-select first session
+  useEffect(() => {
+    if (!selectedId && sessions.length > 0) {
+      setSelectedId(sessions[0].id)
+    }
+  }, [sessions, selectedId])
+
+  const filteredSessions = sessions.filter((s) => {
+    if (statusFilter && s.status !== statusFilter) return false
+    return true
+  })
+
+  const selectedSession = sessions.find((s) => s.id === selectedId)
+
+  const agentOptions = [
+    { value: '', label: 'All Agents' },
+    ...agents.map((a) => ({ value: a.name, label: a.name })),
+  ]
+
+  const statusOptions = [
+    { value: '', label: 'All Statuses' },
+    { value: 'active', label: 'Active' },
+    { value: 'paused', label: 'Paused' },
+    { value: 'ended', label: 'Ended' },
+    { value: 'error', label: 'Error' },
+  ]
+
+  return (
+    <div className="flex h-[calc(100vh-5rem)] gap-4">
+      {/* Left: Session List */}
+      <div className="w-80 shrink-0 flex flex-col">
+        <div className="mb-4">
+          <h1 className="text-2xl font-bold text-white">Sessions</h1>
+        </div>
+        <div className="flex gap-2 mb-3">
+          <Select
+            options={agentOptions}
+            value={agentFilter}
+            onChange={(e) => setAgentFilter(e.target.value)}
+            className="flex-1 h-8 text-xs"
+          />
+          <Select
+            options={statusOptions}
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="flex-1 h-8 text-xs"
+          />
+        </div>
+        <div className="flex-1 overflow-auto space-y-1 scrollbar-thin">
+          {loading ? (
+            <div className="space-y-2">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <ShimmerBlock key={i} height={64} />
+              ))}
+            </div>
+          ) : filteredSessions.length === 0 ? (
+            <p className="text-sm text-white/40 text-center py-8">
+              No sessions found
+            </p>
+          ) : (
+            filteredSessions.map((session) => (
+              <button
+                key={session.id}
+                onClick={() => setSelectedId(session.id)}
+                className={cn(
+                  'w-full text-left rounded-lg border px-3 py-2.5 transition-colors',
+                  selectedId === session.id
+                    ? 'bg-indigo-500/10 border-indigo-500/30'
+                    : 'border-transparent hover:bg-white/5'
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-white truncate">
+                    {session.agentName}
+                  </span>
+                  <StatusBadge status={session.status} />
+                </div>
+                <div className="flex items-center justify-between mt-1">
+                  <span className="text-xs text-white/30 font-mono">
+                    {truncateId(session.id)}
+                  </span>
+                  <span className="text-xs text-white/30">
+                    {formatRelativeTime(session.createdAt)}
+                  </span>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Right: Detail */}
+      <div className="flex-1 min-w-0">
+        {selectedSession ? (
+          <SessionDetail session={selectedSession} />
+        ) : (
+          <EmptyState
+            icon={<Activity className="h-12 w-12" />}
+            title="Select a session"
+            description="Choose a session from the list to view details"
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Session Detail ───
+
+function SessionDetail({ session }: { session: Session }) {
+  const [tab, setTab] = useState<'messages' | 'events' | 'terminal'>('messages')
+  const [messages, setMessages] = useState<Message[]>([])
+  const [events, setEvents] = useState<SessionEvent[]>([])
+  const [logs, setLogs] = useState<string[]>([])
+  const [loadingData, setLoadingData] = useState(true)
+
+  const fetchData = useCallback(async () => {
+    setLoadingData(true)
+    try {
+      const client = getClient()
+      const [msgs, evts] = await Promise.all([
+        client.listMessages(session.id).catch(() => []),
+        client.listSessionEvents(session.id).catch(() => []),
+      ])
+      setMessages(msgs)
+      setEvents(evts)
+    } catch {
+      // Silently handle errors
+    } finally {
+      setLoadingData(false)
+    }
+  }, [session.id])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  // Auto-refresh for active sessions
+  useEffect(() => {
+    if (session.status !== 'active') return
+    const interval = setInterval(fetchData, 5000)
+    return () => clearInterval(interval)
+  }, [session.status, fetchData])
+
+  // Fetch logs when terminal tab is selected
+  useEffect(() => {
+    if (tab !== 'terminal') return
+    const fetchLogs = async () => {
+      try {
+        const result = await getClient().getSessionLogs(session.id)
+        if (result?.logs) {
+          setLogs(result.logs.map((l) => l.text))
+        }
+      } catch {
+        setLogs(['Failed to load logs'])
+      }
+    }
+    fetchLogs()
+    if (session.status === 'active') {
+      const interval = setInterval(fetchLogs, 2000)
+      return () => clearInterval(interval)
+    }
+  }, [tab, session.id, session.status])
+
+  async function handleAction(action: 'pause' | 'resume' | 'stop' | 'end') {
+    const client = getClient()
+    try {
+      if (action === 'pause') await client.pauseSession(session.id)
+      else if (action === 'resume') await client.resumeSession(session.id)
+      else if (action === 'stop') await client.stopSession(session.id)
+      else if (action === 'end') await client.endSession(session.id)
+    } catch (e) {
+      console.error(`Failed to ${action} session:`, e)
+    }
+  }
+
+  return (
+    <Card className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+        <div>
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-semibold text-white">{session.agentName}</h2>
+            <StatusBadge status={session.status} />
+          </div>
+          <div className="flex items-center gap-4 mt-1">
+            <span className="text-xs text-white/30 font-mono">{session.id}</span>
+            <span className="text-xs text-white/30">
+              {formatRelativeTime(session.createdAt)}
+            </span>
+            {session.model && <Badge variant="info">{session.model}</Badge>}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {session.status === 'active' && (
+            <>
+              <Button size="sm" variant="ghost" onClick={() => handleAction('pause')} title="Pause">
+                <Pause className="h-4 w-4" />
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => handleAction('stop')} title="Stop">
+                <Square className="h-4 w-4" />
+              </Button>
+            </>
+          )}
+          {(session.status === 'paused' || session.status === 'stopped') && (
+            <Button size="sm" variant="ghost" onClick={() => handleAction('resume')} title="Resume">
+              <Play className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => navigator.clipboard.writeText(session.id)}
+            title="Copy ID"
+          >
+            <Copy className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 px-6 py-2 border-b border-white/10">
+        {[
+          { key: 'messages', label: 'Messages', icon: MessageSquare, count: messages.length },
+          { key: 'events', label: 'Events', icon: Activity, count: events.length },
+          { key: 'terminal', label: 'Terminal', icon: Terminal },
+        ].map(({ key, label, icon: Icon, count }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key as typeof tab)}
+            className={cn(
+              'flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+              tab === key
+                ? 'bg-white/10 text-white'
+                : 'text-white/40 hover:text-white/70'
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+            {count !== undefined && count > 0 && (
+              <span className="text-xs text-white/30">{count}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="flex-1 overflow-auto p-6 scrollbar-thin">
+        {loadingData ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <ShimmerBlock key={i} height={60} />
+            ))}
+          </div>
+        ) : tab === 'messages' ? (
+          <MessagesTab messages={messages} />
+        ) : tab === 'events' ? (
+          <EventsTab events={events} />
+        ) : (
+          <TerminalTab logs={logs} />
+        )}
+      </div>
+    </Card>
+  )
+}
+
+// ─── Messages Tab ───
+
+function MessagesTab({ messages }: { messages: Message[] }) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages.length])
+
+  if (messages.length === 0) {
+    return (
+      <p className="text-sm text-white/40 text-center py-8">
+        No messages yet
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {messages.map((msg, i) => (
+        <MessageBlock key={msg.id || i} message={msg} />
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  )
+}
+
+function MessageBlock({ message }: { message: Message }) {
+  const isUser = message.role === 'user'
+  const [expanded, setExpanded] = useState(false)
+
+  let displayContent = ''
+  let toolCalls: Array<{ id?: string; name: string; input?: unknown }> = []
+
+  try {
+    const parsed = JSON.parse(message.content)
+    if (Array.isArray(parsed)) {
+      const textBlocks = parsed.filter(
+        (b: Record<string, unknown>) => b.type === 'text'
+      )
+      toolCalls = parsed.filter(
+        (b: Record<string, unknown>) => b.type === 'tool_use'
+      ) as typeof toolCalls
+      displayContent = textBlocks
+        .map((b: Record<string, unknown>) => String(b.text || ''))
+        .join('\n')
+    } else if (typeof parsed === 'string') {
+      displayContent = parsed
+    } else {
+      displayContent = message.content
+    }
+  } catch {
+    displayContent = message.content
+  }
+
+  return (
+    <div className={cn('rounded-lg border p-4', isUser ? 'border-blue-500/20 bg-blue-500/5' : 'border-white/5 bg-white/[0.02]')}>
+      <div className="flex items-center gap-2 mb-2">
+        <Badge variant={isUser ? 'info' : 'default'}>
+          {isUser ? 'User' : 'Assistant'}
+        </Badge>
+        {message.createdAt && (
+          <span className="text-xs text-white/30">
+            {formatRelativeTime(message.createdAt)}
+          </span>
+        )}
+      </div>
+      {displayContent && (
+        <div className="text-sm text-white/80 whitespace-pre-wrap">{displayContent}</div>
+      )}
+      {toolCalls.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {toolCalls.map((tc, idx) => (
+            <ToolCallDisplay key={tc.id || idx} toolCall={tc} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ToolCallDisplay({ toolCall }: { toolCall: { id?: string; name: string; input?: unknown } }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="rounded-md border border-white/10 bg-black/20 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="flex items-center gap-2 w-full px-3 py-2 text-sm text-white/60 hover:text-white/80 transition-colors"
+      >
+        {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        <span className="font-mono text-indigo-400">{toolCall.name}</span>
+      </button>
+      {expanded && (
+        <div className="px-3 pb-3">
+          <div className="text-xs text-white/40 mb-1">Input:</div>
+          <pre className="text-xs text-white/60 overflow-auto max-h-48 bg-black/30 rounded p-2">
+            {JSON.stringify(toolCall.input, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Events Tab ───
+
+function EventsTab({ events }: { events: SessionEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-white/40 text-center py-8">
+        No events recorded
+      </p>
+    )
+  }
+
+  const eventTypeColors: Record<string, string> = {
+    text: 'text-blue-400',
+    tool_start: 'text-purple-400',
+    tool_result: 'text-purple-400',
+    reasoning: 'text-amber-400',
+    error: 'text-red-400',
+    turn_complete: 'text-green-400',
+    lifecycle: 'text-zinc-400',
+  }
+
+  return (
+    <div className="space-y-1">
+      {events.map((event, i) => (
+        <EventRow key={event.id || i} event={event} typeColors={eventTypeColors} />
+      ))}
+    </div>
+  )
+}
+
+function EventRow({
+  event,
+  typeColors,
+}: {
+  event: SessionEvent
+  typeColors: Record<string, string>
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const color = typeColors[event.type] || 'text-white/40'
+
+  let summary = ''
+  try {
+    const data =
+      typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+    if (data && typeof data === 'object') {
+      const d = data as Record<string, unknown>
+      if (typeof d.text === 'string') summary = d.text.slice(0, 100)
+      else if (typeof d.name === 'string') summary = d.name
+      else if (typeof d.error === 'string') summary = d.error.slice(0, 100)
+    }
+  } catch {
+    // event.data is not valid JSON — ignore
+  }
+
+  return (
+    <div className="rounded-md border border-white/5 bg-white/[0.01]">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="flex items-center gap-3 w-full px-3 py-2 text-sm hover:bg-white/[0.02] transition-colors"
+      >
+        {expanded ? <ChevronDown className="h-3 w-3 text-white/30" /> : <ChevronRight className="h-3 w-3 text-white/30" />}
+        <span className="text-xs text-white/20 font-mono w-8">#{event.sequence}</span>
+        <Badge className={color}>{event.type}</Badge>
+        <span className="text-xs text-white/40 truncate flex-1 text-left">{summary}</span>
+        <span className="text-xs text-white/20">
+          {event.createdAt ? formatRelativeTime(event.createdAt) : ''}
+        </span>
+      </button>
+      {expanded && (
+        <div className="px-3 pb-3 pt-1">
+          <pre className="text-xs text-white/50 overflow-auto max-h-64 bg-black/30 rounded p-2">
+            {typeof event.data === 'string' ? event.data : JSON.stringify(event.data, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Terminal Tab ───
+
+function TerminalTab({ logs }: { logs: string[] }) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [logs.length])
+
+  if (logs.length === 0) {
+    return (
+      <p className="text-sm text-white/40 text-center py-8">
+        No terminal output
+      </p>
+    )
+  }
+
+  return (
+    <div className="bg-black/40 rounded-lg p-4 font-mono text-xs">
+      {logs.map((line, i) => (
+        <div key={i} className="text-white/60 whitespace-pre-wrap">
+          {line}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/packages/dashboard/app/settings/api-keys/page.tsx
+++ b/packages/dashboard/app/settings/api-keys/page.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { getAuthHeaders } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import { Copy, Key, Plus, Trash2 } from 'lucide-react'
+
+interface ApiKey {
+  id: string
+  label: string
+  keyPrefix?: string
+  createdAt: string
+}
+
+export default function ApiKeysPage() {
+  const [keys, setKeys] = useState<ApiKey[]>([])
+  const [loading, setLoading] = useState(true)
+  const [newKeyName, setNewKeyName] = useState('')
+  const [createdKey, setCreatedKey] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function fetchKeys() {
+    try {
+      const res = await fetch('/api/api-keys', {
+        headers: getAuthHeaders(),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setKeys(data.keys || data || [])
+      }
+    } catch {
+      // Endpoint may not exist yet
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchKeys()
+  }, [])
+
+  async function handleCreate() {
+    if (!newKeyName.trim()) {
+      setError('Key name is required')
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/api-keys', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders(),
+        },
+        body: JSON.stringify({ label: newKeyName.trim() }),
+      })
+
+      if (!res.ok) throw new Error('Failed to create key')
+
+      const data = await res.json()
+      setCreatedKey(data.key)
+      setNewKeyName('')
+      fetchKeys()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to create key'
+      setError(message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    try {
+      const res = await fetch(`/api/api-keys/${id}`, {
+        method: 'DELETE',
+        headers: getAuthHeaders(),
+      })
+      if (!res.ok) throw new Error('Failed to revoke key')
+      fetchKeys()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to revoke key'
+      setError(message)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-white">API Keys</h1>
+        <p className="mt-1 text-sm text-white/50">
+          Create API keys to authenticate with the Ash server
+        </p>
+      </div>
+
+      {/* Create key */}
+      <Card>
+        <CardContent>
+          <div className="flex gap-3">
+            <Input
+              placeholder="Key name (e.g. production)"
+              value={newKeyName}
+              onChange={(e) => setNewKeyName(e.target.value)}
+              className="flex-1"
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+            />
+            <Button onClick={handleCreate} disabled={creating}>
+              <Plus className="h-4 w-4 mr-2" />
+              {creating ? 'Creating...' : 'Create Key'}
+            </Button>
+          </div>
+          {error && <p className="text-sm text-red-400 mt-2">{error}</p>}
+        </CardContent>
+      </Card>
+
+      {/* Newly created key */}
+      {createdKey && (
+        <Card className="border-green-500/30">
+          <CardContent>
+            <div className="flex items-center gap-2 mb-2">
+              <Key className="h-4 w-4 text-green-400" />
+              <p className="text-sm font-medium text-green-400">
+                Key created! Copy it now — it won&apos;t be shown again.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 bg-black/30 rounded-lg px-4 py-3">
+              <code className="flex-1 text-sm text-white font-mono break-all">
+                {createdKey}
+              </code>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  navigator.clipboard.writeText(createdKey)
+                }}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Getting started */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Getting Started</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg bg-black/30 p-4 font-mono text-sm text-white/80 space-y-1">
+            <div className="text-white/40"># Set your API key</div>
+            <div>export ASH_API_KEY=ash_sk_...</div>
+            <div className="text-white/40 mt-3"># Deploy an agent</div>
+            <div>ash deploy ./my-agent --name my-agent</div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Key list */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Active Keys</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-4 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={40} />
+              ))}
+            </div>
+          ) : keys.length === 0 ? (
+            <p className="text-sm text-white/40 text-center py-8">
+              No API keys yet
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Name</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Key</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Created</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {keys.map((key) => (
+                  <tr key={key.id} className="hover:bg-white/[0.02]">
+                    <td className="px-6 py-3 text-white/80 font-medium">{key.label}</td>
+                    <td className="px-6 py-3 text-white/40 font-mono text-xs">
+                      {key.keyPrefix || '••••••••'}
+                    </td>
+                    <td className="px-6 py-3 text-white/40">
+                      {formatRelativeTime(key.createdAt)}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleRevoke(key.id)}
+                        className="text-red-400 hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/dashboard/app/settings/credentials/page.tsx
+++ b/packages/dashboard/app/settings/credentials/page.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useState } from 'react'
+import { useCredentials } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import { Lock, Plus, Trash2, X } from 'lucide-react'
+
+const CREDENTIAL_TYPES = [
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'bedrock', label: 'AWS Bedrock' },
+  { value: 'custom', label: 'Custom' },
+]
+
+export default function CredentialsPage() {
+  const { credentials, loading, refetch } = useCredentials()
+  const [showCreate, setShowCreate] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete(id: string) {
+    setError(null)
+    try {
+      await getClient().deleteCredential(id)
+      refetch()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to delete credential'
+      setError(message)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Credentials</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Store API keys for LLM providers. Encrypted at rest.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Credential
+        </Button>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-4 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <ShimmerBlock key={i} height={48} />
+              ))}
+            </div>
+          ) : credentials.length === 0 ? (
+            <EmptyState
+              icon={<Lock className="h-12 w-12" />}
+              title="No credentials stored"
+              description="Add API keys for LLM providers to use with your agents."
+              action={
+                <Button onClick={() => setShowCreate(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Credential
+                </Button>
+              }
+            />
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Provider</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Label</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Status</th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-white/40 uppercase">Last Used</th>
+                  <th className="text-right px-6 py-3 text-xs font-medium text-white/40 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {credentials.map((cred) => (
+                  <tr key={cred.id} className="hover:bg-white/[0.02]">
+                    <td className="px-6 py-3">
+                      <Badge variant="info">{cred.type}</Badge>
+                    </td>
+                    <td className="px-6 py-3 text-white/80">{cred.label || '-'}</td>
+                    <td className="px-6 py-3">
+                      <Badge variant={cred.active ? 'success' : 'default'}>
+                        {cred.active ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </td>
+                    <td className="px-6 py-3 text-white/40">
+                      {cred.lastUsedAt ? formatRelativeTime(cred.lastUsedAt) : 'Never'}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(cred.id)}
+                        className="text-red-400 hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {showCreate && (
+        <CreateCredentialModal
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false)
+            refetch()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function CreateCredentialModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [type, setType] = useState('anthropic')
+  const [label, setLabel] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [accessKeyId, setAccessKeyId] = useState('')
+  const [secretKey, setSecretKey] = useState('')
+  const [region, setRegion] = useState('us-east-1')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleCreate() {
+    setCreating(true)
+    setError(null)
+
+    try {
+      const client = getClient()
+      if (type === 'bedrock') {
+        await client.storeBedrockCredential({
+          accessKeyId,
+          secretAccessKey: secretKey,
+          region,
+          label: label || undefined,
+        })
+      } else {
+        await client.storeCredential(type, apiKey, label || undefined)
+      }
+      onCreated()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to store credential'
+      setError(message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-md">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">Add Credential</h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <Select
+              label="Provider"
+              options={CREDENTIAL_TYPES}
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+            />
+
+            <Input
+              label="Label (optional)"
+              placeholder="e.g. production"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+
+            {type === 'bedrock' ? (
+              <>
+                <Input
+                  label="Access Key ID"
+                  placeholder="AKIA..."
+                  value={accessKeyId}
+                  onChange={(e) => setAccessKeyId(e.target.value)}
+                />
+                <Input
+                  label="Secret Access Key"
+                  type="password"
+                  value={secretKey}
+                  onChange={(e) => setSecretKey(e.target.value)}
+                />
+                <Input
+                  label="Region"
+                  placeholder="us-east-1"
+                  value={region}
+                  onChange={(e) => setRegion(e.target.value)}
+                />
+              </>
+            ) : (
+              <Input
+                label="API Key"
+                type="password"
+                placeholder={type === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+              />
+            )}
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleCreate} disabled={creating}>
+                {creating ? 'Saving...' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/dashboard/components/nav.tsx
+++ b/packages/dashboard/components/nav.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { useHealth } from '@/lib/hooks'
+import {
+  Activity,
+  Bot,
+  Code2,
+  Key,
+  LayoutDashboard,
+  ListOrdered,
+  Lock,
+  ScrollText,
+  Settings,
+  TrendingUp,
+} from 'lucide-react'
+
+export interface NavItem {
+  href: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  external?: boolean
+}
+
+interface DashboardNavProps {
+  extraItems?: NavItem[]
+  extraBottomLinks?: NavItem[]
+  branding?: string
+}
+
+const navItems: NavItem[] = [
+  { href: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/playground', label: 'Playground', icon: Code2 },
+  { href: '/agents', label: 'Agents', icon: Bot },
+  { href: '/sessions', label: 'Sessions', icon: Activity },
+  { href: '/logs', label: 'Logs', icon: ScrollText },
+  { href: '/analytics', label: 'Analytics', icon: TrendingUp },
+]
+
+const bottomLinks: NavItem[] = [
+  { href: '/settings/api-keys', label: 'API Keys', icon: Key },
+  { href: '/settings/credentials', label: 'Credentials', icon: Lock },
+  { href: '/queue', label: 'Queue', icon: ListOrdered },
+]
+
+export function DashboardNav({ extraItems, extraBottomLinks, branding }: DashboardNavProps) {
+  const pathname = usePathname()
+  const { health } = useHealth()
+
+  const allItems = extraItems ? [...navItems, ...extraItems] : navItems
+  const allBottomLinks = extraBottomLinks ? [...bottomLinks, ...extraBottomLinks] : bottomLinks
+
+  const isHealthy = health?.status === 'ok'
+
+  return (
+    <nav className="fixed inset-y-0 left-0 z-50 w-64 flex flex-col border-r border-white/10 bg-[#0d1117]">
+      {/* Logo */}
+      <div className="flex h-16 items-center gap-3 px-5 border-b border-white/10">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-indigo-500">
+          <span className="text-sm font-bold text-white">A</span>
+        </div>
+        <div className="min-w-0">
+          <span className="text-white font-bold tracking-tight block">
+            {branding || 'Ash'}
+          </span>
+          <div className="flex items-center gap-1.5 text-white/40 text-xs font-mono">
+            <span
+              className={cn(
+                'w-1.5 h-1.5 rounded-full',
+                isHealthy ? 'bg-green-400 animate-pulse' : 'bg-red-400'
+              )}
+            />
+            {isHealthy ? 'ONLINE' : 'OFFLINE'}
+          </div>
+        </div>
+      </div>
+
+      {/* Main nav */}
+      <div className="flex-1 overflow-auto px-3 py-4 scrollbar-thin">
+        <div className="space-y-0.5">
+          {allItems.map((item) => {
+            const isActive =
+              pathname === item.href ||
+              (item.href !== '/' && pathname.startsWith(item.href))
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200',
+                  isActive
+                    ? 'bg-indigo-500/10 text-indigo-400 border border-indigo-500/30'
+                    : 'text-white/60 hover:text-white hover:bg-white/5 border border-transparent'
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+                {isActive && (
+                  <div className="ml-auto w-1.5 h-1.5 rounded-full bg-indigo-400 animate-pulse" />
+                )}
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Bottom links */}
+      <div className="border-t border-white/10 px-3 py-3 space-y-0.5">
+        {allBottomLinks.map((item) => {
+          const isActive = !item.external && pathname.startsWith(item.href)
+          if (item.external) {
+            return (
+              <a
+                key={item.label}
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-white/40 hover:text-white hover:bg-white/5 transition-all duration-200"
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </a>
+            )
+          }
+          return (
+            <Link
+              key={item.label}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200',
+                isActive
+                  ? 'text-indigo-400'
+                  : 'text-white/40 hover:text-white hover:bg-white/5'
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          )
+        })}
+        {health?.version && (
+          <div className="px-3 py-2 text-xs text-white/20 font-mono">
+            v{health.version}
+          </div>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/packages/dashboard/components/providers.tsx
+++ b/packages/dashboard/components/providers.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { AshClient } from '@ash-ai/sdk'
+import { getClient } from '@/lib/client'
+
+const AshContext = createContext<AshClient | null>(null)
+
+export function AshProvider({ children }: { children: React.ReactNode }) {
+  const client = getClient()
+  return <AshContext.Provider value={client}>{children}</AshContext.Provider>
+}
+
+export function useAshClient(): AshClient {
+  const client = useContext(AshContext)
+  if (!client) throw new Error('useAshClient must be used within AshProvider')
+  return client
+}

--- a/packages/dashboard/components/ui/badge.tsx
+++ b/packages/dashboard/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils'
+
+export interface BadgeProps {
+  children: React.ReactNode
+  variant?: 'default' | 'success' | 'warning' | 'error' | 'info'
+  className?: string
+}
+
+const variants = {
+  default: 'bg-white/10 text-white/70 border border-white/10',
+  success: 'bg-green-500/20 text-green-400 border border-green-500/30',
+  warning: 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30',
+  error: 'bg-red-500/20 text-red-400 border border-red-500/30',
+  info: 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
+}
+
+export function Badge({ children, variant = 'default', className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+        variants[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  const variant =
+    ({
+      active: 'success',
+      starting: 'info',
+      paused: 'warning',
+      stopped: 'default',
+      ended: 'default',
+      error: 'error',
+    } as Record<string, BadgeProps['variant']>)[status] || 'default'
+
+  return <Badge variant={variant}>{status}</Badge>
+}

--- a/packages/dashboard/components/ui/button.tsx
+++ b/packages/dashboard/components/ui/button.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils'
+import { forwardRef } from 'react'
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger'
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const variantStyles = {
+  primary:
+    'bg-indigo-500 text-white font-medium hover:bg-indigo-400',
+  secondary:
+    'border border-white/20 bg-white/5 text-white hover:bg-white/10 hover:border-white/30',
+  ghost: 'text-white/70 hover:text-white hover:bg-white/10',
+  danger:
+    'bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30',
+}
+
+const sizeStyles = {
+  sm: 'h-8 px-3 text-xs rounded-lg',
+  md: 'h-9 px-4 text-sm rounded-xl',
+  lg: 'h-10 px-6 text-sm rounded-xl',
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', size = 'md', disabled, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center font-medium transition-all duration-200',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50',
+          'disabled:pointer-events-none disabled:opacity-50',
+          variantStyles[variant],
+          sizeStyles[size],
+          className
+        )}
+        disabled={disabled}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/packages/dashboard/components/ui/card.tsx
+++ b/packages/dashboard/components/ui/card.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils'
+
+interface CardProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function Card({ children, className }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border border-white/10 bg-[#1c2129] transition-all duration-200',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function CardHeader({ children, className }: CardProps) {
+  return (
+    <div className={cn('flex flex-col space-y-1.5 px-4 pt-4 pb-0 sm:px-6 sm:pt-6 sm:pb-0', className)}>
+      {children}
+    </div>
+  )
+}
+
+export function CardTitle({ children, className }: CardProps) {
+  return (
+    <h3 className={cn('text-lg font-semibold leading-none tracking-tight text-white', className)}>
+      {children}
+    </h3>
+  )
+}
+
+export function CardContent({ children, className }: CardProps) {
+  return (
+    <div className={cn('p-4 sm:p-6', className)}>
+      {children}
+    </div>
+  )
+}

--- a/packages/dashboard/components/ui/empty-state.tsx
+++ b/packages/dashboard/components/ui/empty-state.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib/utils'
+
+interface EmptyStateProps {
+  icon?: React.ReactNode
+  title: string
+  description: string
+  action?: React.ReactNode
+  className?: string
+}
+
+export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center py-16 text-center', className)}>
+      {icon && <div className="mb-4 text-white/30">{icon}</div>}
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      <p className="mt-1 max-w-sm text-sm text-white/50">{description}</p>
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}

--- a/packages/dashboard/components/ui/input.tsx
+++ b/packages/dashboard/components/ui/input.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils'
+import { forwardRef } from 'react'
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string
+  error?: string
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, label, error, id, ...props }, ref) => {
+    return (
+      <div className="space-y-1.5">
+        {label && (
+          <label htmlFor={id} className="block text-sm font-medium text-white/70">
+            {label}
+          </label>
+        )}
+        <input
+          ref={ref}
+          id={id}
+          className={cn(
+            'flex h-9 w-full rounded-xl border px-3 py-1 text-sm transition-all duration-200',
+            'bg-white/5 border-white/10 text-white placeholder:text-white/40',
+            'focus-visible:outline-none focus-visible:border-indigo-500/50 focus-visible:bg-white/10',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            error && 'border-red-500/50 focus-visible:border-red-400',
+            className
+          )}
+          {...props}
+        />
+        {error && <p className="text-xs text-red-400">{error}</p>}
+      </div>
+    )
+  }
+)
+Input.displayName = 'Input'

--- a/packages/dashboard/components/ui/select.tsx
+++ b/packages/dashboard/components/ui/select.tsx
@@ -1,0 +1,50 @@
+import { cn } from '@/lib/utils'
+import { forwardRef } from 'react'
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string
+  options: Array<{ value: string; label: string; disabled?: boolean }>
+  placeholder?: string
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, label, options, placeholder, id, ...props }, ref) => {
+    return (
+      <div className="space-y-1.5">
+        {label && (
+          <label htmlFor={id} className="block text-sm font-medium text-white/70">
+            {label}
+          </label>
+        )}
+        <select
+          ref={ref}
+          id={id}
+          className={cn(
+            'flex h-9 w-full rounded-xl border px-3 py-1 text-sm transition-all duration-200',
+            'bg-white/5 border-white/10 text-white',
+            'focus-visible:outline-none focus-visible:border-indigo-500/50',
+            className
+          )}
+          {...props}
+        >
+          {placeholder && (
+            <option value="" className="bg-[#1c2129]">
+              {placeholder}
+            </option>
+          )}
+          {options.map((opt) => (
+            <option
+              key={opt.value}
+              value={opt.value}
+              disabled={opt.disabled}
+              className="bg-[#1c2129]"
+            >
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+)
+Select.displayName = 'Select'

--- a/packages/dashboard/components/ui/shimmer.tsx
+++ b/packages/dashboard/components/ui/shimmer.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils'
+
+export function ShimmerLine({
+  width = '100%',
+  height = 16,
+  className,
+}: {
+  width?: string | number
+  height?: number
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md',
+        'bg-gradient-to-r from-white/5 via-white/10 to-white/5',
+        'bg-[length:200%_100%]',
+        'animate-[shimmer_1.5s_ease-in-out_infinite]',
+        className
+      )}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height,
+      }}
+    />
+  )
+}
+
+export function ShimmerBlock({
+  width = '100%',
+  height = 100,
+  className,
+}: {
+  width?: string | number
+  height?: number
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl',
+        'bg-gradient-to-r from-white/5 via-white/10 to-white/5',
+        'bg-[length:200%_100%]',
+        'animate-[shimmer_1.5s_ease-in-out_infinite]',
+        className
+      )}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height,
+      }}
+    />
+  )
+}

--- a/packages/dashboard/lib/client.ts
+++ b/packages/dashboard/lib/client.ts
@@ -1,0 +1,41 @@
+import { AshClient } from '@ash-ai/sdk'
+
+let client: AshClient | null = null
+let cachedApiKey: string | undefined
+
+declare global {
+  interface Window {
+    __ASH_CONFIG__?: { apiKey?: string; serverVersion?: string; serverUrl?: string }
+  }
+}
+
+export function getClient(): AshClient {
+  if (!client) {
+    // In the browser, prefer the server URL from config (points directly to the Ash server,
+    // bypassing the Next.js dev proxy which can break SSE streams).
+    // Falls back to window.location.origin (works when served by the Ash server itself).
+    const serverUrl =
+      typeof window !== 'undefined'
+        ? window.__ASH_CONFIG__?.serverUrl || window.location.origin
+        : process.env.NEXT_PUBLIC_ASH_API_URL || 'http://localhost:4100'
+
+    cachedApiKey =
+      typeof window !== 'undefined'
+        ? window.__ASH_CONFIG__?.apiKey
+        : process.env.ASH_API_KEY
+
+    client = new AshClient({ serverUrl, apiKey: cachedApiKey })
+  }
+  return client
+}
+
+/** Return auth headers matching the SDK client's config. */
+export function getAuthHeaders(): Record<string, string> {
+  getClient() // ensure cachedApiKey is set
+  return cachedApiKey ? { Authorization: `Bearer ${cachedApiKey}` } : {}
+}
+
+export function resetClient(): void {
+  client = null
+  cachedApiKey = undefined
+}

--- a/packages/dashboard/lib/exports.ts
+++ b/packages/dashboard/lib/exports.ts
@@ -1,0 +1,55 @@
+/**
+ * @ash-ai/dashboard public API
+ *
+ * This barrel exports components, hooks, and utilities for use by consumers
+ * like the ash-cloud-platform. Pages are exported as named components so they
+ * can be wrapped with auth / context by the consuming app.
+ *
+ * NOTE: All page components are React Client Components ('use client').
+ * They rely on the AshProvider context or getClient() for data fetching.
+ */
+
+// ─── Page Components ─────────────────────────────────────────────────────────
+export { default as DashboardHomePage } from '@/app/page'
+export { default as AgentsPage } from '@/app/agents/page'
+export { default as SessionsPage } from '@/app/sessions/page'
+export { default as PlaygroundPage } from '@/app/playground/page'
+export { default as LogsPage } from '@/app/logs/page'
+export { default as AnalyticsPage } from '@/app/analytics/page'
+export { default as ApiKeysPage } from '@/app/settings/api-keys/page'
+export { default as CredentialsPage } from '@/app/settings/credentials/page'
+export { default as QueuePage } from '@/app/queue/page'
+
+// ─── Navigation ──────────────────────────────────────────────────────────────
+export { DashboardNav } from '@/components/nav'
+export type { NavItem } from '@/components/nav'
+
+// ─── UI Primitives ───────────────────────────────────────────────────────────
+export { Badge, StatusBadge } from '@/components/ui/badge'
+export type { BadgeProps } from '@/components/ui/badge'
+export { Button } from '@/components/ui/button'
+export { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+export { EmptyState } from '@/components/ui/empty-state'
+export { Input } from '@/components/ui/input'
+export { Select } from '@/components/ui/select'
+export { ShimmerBlock } from '@/components/ui/shimmer'
+
+// ─── Data Layer ──────────────────────────────────────────────────────────────
+export { AshProvider, useAshClient } from '@/components/providers'
+export { getClient, getAuthHeaders, resetClient } from '@/lib/client'
+export {
+  useAgents,
+  useSessions,
+  useHealth,
+  useCredentials,
+  useUsageStats,
+} from '@/lib/hooks'
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
+export {
+  cn,
+  formatRelativeTime,
+  formatNumber,
+  formatDuration,
+  truncateId,
+} from '@/lib/utils'

--- a/packages/dashboard/lib/hooks.ts
+++ b/packages/dashboard/lib/hooks.ts
@@ -1,0 +1,169 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getClient } from './client'
+import type { Agent, Session, Credential } from '@ash-ai/shared'
+
+// ─── useInterval ───
+
+function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback)
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+  useEffect(() => {
+    if (delay === null) return
+    const id = setInterval(() => savedCallback.current(), delay)
+    return () => clearInterval(id)
+  }, [delay])
+}
+
+// ─── useAgents ───
+
+export function useAgents() {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await getClient().listAgents()
+      setAgents(result)
+      setError(null)
+    } catch (e) {
+      setError(e as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { agents, loading, error, refetch }
+}
+
+// ─── useSessions ───
+
+export function useSessions(opts?: {
+  agent?: string
+  limit?: number
+  autoRefresh?: boolean
+}) {
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await getClient().listSessions(opts?.agent)
+      setSessions(result)
+      setError(null)
+    } catch (e) {
+      setError(e as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [opts?.agent])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  useInterval(
+    () => refetch(),
+    opts?.autoRefresh !== false ? 10_000 : null
+  )
+
+  return { sessions, loading, error, refetch }
+}
+
+// ─── useHealth ───
+
+export interface HealthData {
+  status: string
+  version?: string
+  activeSessions?: number
+  activeSandboxes?: number
+}
+
+export function useHealth() {
+  const [health, setHealth] = useState<HealthData | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await getClient().health()
+      setHealth(result as HealthData)
+      setError(null)
+    } catch (e) {
+      setError(e as Error)
+    }
+  }, [])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  useInterval(() => refetch(), 30_000)
+
+  return { health, error, refetch }
+}
+
+// ─── useCredentials ───
+
+export function useCredentials() {
+  const [credentials, setCredentials] = useState<Credential[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await getClient().listCredentials()
+      setCredentials(result)
+      setError(null)
+    } catch (e) {
+      setError(e as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { credentials, loading, error, refetch }
+}
+
+// ─── useUsageStats ───
+
+export type { UsageStats } from '@ash-ai/shared'
+
+export function useUsageStats(opts?: {
+  agentName?: string
+  sessionId?: string
+}) {
+  const [stats, setStats] = useState<import('@ash-ai/shared').UsageStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await getClient().getUsageStats(opts)
+      setStats(result)
+      setError(null)
+    } catch (e) {
+      setError(e as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [opts?.agentName, opts?.sessionId])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { stats, loading, error, refetch }
+}

--- a/packages/dashboard/lib/utils.ts
+++ b/packages/dashboard/lib/utils.ts
@@ -1,0 +1,44 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}
+
+export function formatRelativeTime(date: string | Date): string {
+  const now = Date.now()
+  const then = new Date(date).getTime()
+  const diff = now - then
+
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+
+  return new Date(date).toLocaleDateString()
+}
+
+export function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return n.toString()
+}
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${Math.floor(seconds % 60)}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m`
+}
+
+export function truncateId(id: string, len = 8): string {
+  return id.length > len ? id.slice(0, len) : id
+}

--- a/packages/dashboard/next-env.d.ts
+++ b/packages/dashboard/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/dashboard/next.config.ts
+++ b/packages/dashboard/next.config.ts
@@ -1,0 +1,28 @@
+import type { NextConfig } from 'next'
+
+const isDev = process.env.NODE_ENV === 'development'
+
+const nextConfig: NextConfig = {
+  output: isDev ? undefined : 'export',
+  basePath: '/dashboard',
+  trailingSlash: true,
+  images: {
+    unoptimized: true,
+  },
+  ...(isDev && {
+    // Skip trailing slash redirects in dev to avoid extra round-trips on /api/* proxy calls
+    skipTrailingSlashRedirect: true,
+    async rewrites() {
+      const ashUrl = process.env.ASH_API_URL || 'http://localhost:4100'
+      return {
+        beforeFiles: [
+          { source: '/api/:path*', destination: `${ashUrl}/api/:path*`, basePath: false as const },
+          { source: '/health', destination: `${ashUrl}/health`, basePath: false as const },
+          { source: '/dashboard/config.js', destination: `${ashUrl}/dashboard/config.js`, basePath: false as const },
+        ],
+      }
+    },
+  }),
+}
+
+export default nextConfig

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ash-ai/dashboard",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 4200",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ash-ai/sdk": "workspace:*",
+    "@ash-ai/shared": "workspace:*",
+    "@ash-ai/ui": "workspace:*",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "next": "^15.3.3",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^2.6.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
+    "@types/node": "^22.15.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^4.1.8",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/dashboard/postcss.config.mjs
+++ b/packages/dashboard/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}
+
+export default config

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -68,6 +68,16 @@ export interface ExecResult {
   stderr: string;
 }
 
+/** Error from Ash runtime API — preserves status code and message. */
+export class AshApiError extends Error {
+  public readonly statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = 'AshApiError';
+    this.statusCode = statusCode;
+  }
+}
+
 export class AshClient {
   private serverUrl: string;
   private apiKey?: string;
@@ -91,8 +101,9 @@ export class AshClient {
       body: body ? JSON.stringify(body) : undefined,
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return await res.json() as T;
   }
@@ -243,8 +254,9 @@ export class AshClient {
       body: JSON.stringify(body),
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return res;
   }
@@ -366,8 +378,9 @@ export class AshClient {
       headers: this.headers(),
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return {
       buffer: Buffer.from(await res.arrayBuffer()),
@@ -382,8 +395,9 @@ export class AshClient {
       headers: this.headers(),
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return res;
   }
@@ -414,6 +428,27 @@ export class AshClient {
     if (label) body.label = label;
     const res = await this.request<{ credential: Credential }>('POST', '/api/credentials', body);
     return res.credential;
+  }
+
+  /**
+   * Store an Amazon Bedrock credential. The credential is encrypted at rest and
+   * expanded into AWS env vars (CLAUDE_CODE_USE_BEDROCK, AWS_ACCESS_KEY_ID, etc.)
+   * when used in a session.
+   */
+  async storeBedrockCredential(opts: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+    sessionToken?: string;
+    label?: string;
+  }): Promise<Credential> {
+    const key = JSON.stringify({
+      accessKeyId: opts.accessKeyId,
+      secretAccessKey: opts.secretAccessKey,
+      region: opts.region,
+      ...(opts.sessionToken && { sessionToken: opts.sessionToken }),
+    });
+    return this.storeCredential('bedrock', key, opts.label);
   }
 
   async listCredentials(): Promise<Credential[]> {
@@ -448,8 +483,9 @@ export class AshClient {
       headers: this.headers(),
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return Buffer.from(await res.arrayBuffer());
   }
@@ -466,8 +502,9 @@ export class AshClient {
       headers: this.headers(),
     });
     if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: res.statusText })) as { error: string };
-      throw new Error(err.error);
+      const err = await res.json().catch(() => ({})) as { error?: string; message?: string };
+      const msg = err.message || err.error || res.statusText;
+      throw new AshApiError(res.status, msg);
     }
     return Buffer.from(await res.arrayBuffer());
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export { AshClient } from './client.js';
+export { AshClient, AshApiError } from './client.js';
 export type { AshClientOptions, SendMessageOptions, ExecResult } from './client.js';
 export { parseSSEStream } from './sse.js';
 export { extractTextFromEvent, extractStreamDelta, extractDisplayItems } from '@ash-ai/shared';
@@ -11,6 +11,7 @@ export type {
   SessionEvent,
   SessionEventType,
   Credential,
+  CredentialType,
   Attachment,
   QueueItem,
   QueueItemStatus,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "@ash-ai/shared": "workspace:*",
     "@aws-sdk/client-s3": "^3.1004.0",
     "@fastify/cors": "^10.1.0",
+    "@fastify/static": "^8.1.0",
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/swagger": "^9.7.0",

--- a/packages/server/src/__tests__/bedrock-credential.test.ts
+++ b/packages/server/src/__tests__/bedrock-credential.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Fastify from 'fastify';
+import { registerSchemas } from '../schemas.js';
+import { sessionRoutes } from '../routes/sessions.js';
+import { initDb, closeDb, upsertAgent } from '../db/index.js';
+import type { RunnerCoordinator } from '../runner/coordinator.js';
+
+// Mock decryptCredential to avoid needing ASH_CREDENTIAL_KEY at module load time
+vi.mock('../routes/credentials.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../routes/credentials.js')>();
+  return {
+    ...orig,
+    decryptCredential: vi.fn(),
+  };
+});
+
+import { decryptCredential } from '../routes/credentials.js';
+const mockDecrypt = vi.mocked(decryptCredential);
+
+function mockCoordinator(captureOpts?: { createSandboxOpts?: any[] }): RunnerCoordinator {
+  return {
+    selectBackend: async () => ({
+      backend: {
+        createSandbox: async (opts: any) => {
+          if (captureOpts) captureOpts.createSandboxOpts!.push(opts);
+          return { sandboxId: 'sbx-1', workspaceDir: '/tmp/ws' };
+        },
+      },
+      runnerId: '__local__',
+    }),
+    getBackendForRunnerAsync: async () => ({}),
+  } as unknown as RunnerCoordinator;
+}
+
+function noopTelemetry() {
+  return { emit() {}, async flush() {}, async shutdown() {} } as any;
+}
+
+describe('Bedrock credential support', () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'ash-bedrock-test-'));
+    await initDb({ dataDir });
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('bedrock credential expands to AWS env vars in sandbox', async () => {
+    const captured: any[] = [];
+
+    const agentDir = join(dataDir, 'agents', 'bedrock-agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test agent');
+    await upsertAgent('bedrock-agent', agentDir);
+
+    // Mock decrypt to return bedrock credential
+    mockDecrypt.mockResolvedValue({
+      type: 'bedrock',
+      key: JSON.stringify({
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        region: 'us-west-2',
+      }),
+    });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator({ createSandboxOpts: captured }), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'bedrock-agent', credentialId: 'cred-bedrock-1' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(captured).toHaveLength(1);
+
+    const env = captured[0].extraEnv;
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(env.AWS_ACCESS_KEY_ID).toBe('AKIAIOSFODNN7EXAMPLE');
+    expect(env.AWS_SECRET_ACCESS_KEY).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+    expect(env.AWS_REGION).toBe('us-west-2');
+    expect(env.AWS_SESSION_TOKEN).toBeUndefined();
+  });
+
+  it('bedrock credential with session token includes AWS_SESSION_TOKEN', async () => {
+    const captured: any[] = [];
+
+    const agentDir = join(dataDir, 'agents', 'bedrock-agent2');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('bedrock-agent2', agentDir);
+
+    mockDecrypt.mockResolvedValue({
+      type: 'bedrock',
+      key: JSON.stringify({
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        region: 'eu-west-1',
+        sessionToken: 'FwoGZXIvYXdzEBAaDHka0example',
+      }),
+    });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator({ createSandboxOpts: captured }), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'bedrock-agent2', credentialId: 'cred-bedrock-2' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const env = captured[0].extraEnv;
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(env.AWS_SESSION_TOKEN).toBe('FwoGZXIvYXdzEBAaDHka0example');
+  });
+
+  it('rejects bedrock credential with invalid JSON', async () => {
+    const agentDir = join(dataDir, 'agents', 'bedrock-agent3');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('bedrock-agent3', agentDir);
+
+    mockDecrypt.mockResolvedValue({
+      type: 'bedrock',
+      key: 'not-valid-json',
+    });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator(), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'bedrock-agent3', credentialId: 'cred-bedrock-bad' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('JSON object');
+  });
+
+  it('rejects bedrock credential missing required fields', async () => {
+    const agentDir = join(dataDir, 'agents', 'bedrock-agent4');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('bedrock-agent4', agentDir);
+
+    mockDecrypt.mockResolvedValue({
+      type: 'bedrock',
+      key: JSON.stringify({ accessKeyId: 'AKIAEXAMPLE', region: 'us-east-1' }),
+    });
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator(), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: { agent: 'bedrock-agent4', credentialId: 'cred-bedrock-incomplete' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('accessKeyId');
+  });
+
+  it('direct extraEnv works for bedrock without credential system', async () => {
+    const captured: any[] = [];
+
+    const agentDir = join(dataDir, 'agents', 'bedrock-direct');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# Test');
+    await upsertAgent('bedrock-direct', agentDir);
+
+    const app = Fastify();
+    app.decorateRequest('tenantId', '');
+    app.addHook('onRequest', async (req) => { req.tenantId = 'default'; });
+    registerSchemas(app);
+    sessionRoutes(app, mockCoordinator({ createSandboxOpts: captured }), dataDir, noopTelemetry());
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: {
+        agent: 'bedrock-direct',
+        extraEnv: {
+          CLAUDE_CODE_USE_BEDROCK: '1',
+          AWS_ACCESS_KEY_ID: 'AKIADIRECT',
+          AWS_SECRET_ACCESS_KEY: 'secret-direct',
+          AWS_REGION: 'ap-southeast-1',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const env = captured[0].extraEnv;
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(env.AWS_ACCESS_KEY_ID).toBe('AKIADIRECT');
+    expect(env.AWS_SECRET_ACCESS_KEY).toBe('secret-direct');
+    expect(env.AWS_REGION).toBe('ap-southeast-1');
+  });
+});

--- a/packages/server/src/__tests__/dashboard.test.ts
+++ b/packages/server/src/__tests__/dashboard.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { createAshServer, type AshServer } from '../server.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dashboardOut = resolve(__dirname, '..', '..', '..', 'dashboard', 'out');
+
+const TEST_API_KEY = 'test-dashboard-key';
+
+describe('dashboard static serving', () => {
+  let server: AshServer;
+  let dataDir: string;
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'ash-dashboard-test-'));
+
+    // Point ASH_DASHBOARD_PATH at the real dashboard build output
+    process.env.ASH_DASHBOARD_PATH = dashboardOut;
+
+    server = await createAshServer({
+      dataDir,
+      mode: 'standalone',
+      apiKey: TEST_API_KEY,
+    });
+
+    await server.app.ready();
+  }, 30_000);
+
+  afterAll(async () => {
+    delete process.env.ASH_DASHBOARD_PATH;
+    await server.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  // ─── Static File Serving ─────────────────────────────────────────────
+
+  it('serves index.html at /dashboard/', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('<!DOCTYPE html');
+  });
+
+  it('serves index.html at /dashboard/index.html', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/index.html',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  // ─── Route Pages ─────────────────────────────────────────────────────
+
+  it('serves agents page at /dashboard/agents/', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/agents/',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('<!DOCTYPE html');
+  });
+
+  it('serves sessions page at /dashboard/sessions/', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/sessions/',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('serves settings/api-keys page', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/settings/api-keys/',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  // ─── Runtime Config Endpoint ─────────────────────────────────────────
+
+  it('serves /dashboard/config.js with runtime API key and version', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/config.js',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/javascript');
+    expect(res.body).toContain('window.__ASH_CONFIG__');
+    expect(res.body).toContain(TEST_API_KEY);
+
+    // Verify it's valid JS with parseable JSON
+    const match = res.body.match(/window\.__ASH_CONFIG__\s*=\s*(.+);/);
+    expect(match).not.toBeNull();
+    const config = JSON.parse(match![1]);
+    expect(config.apiKey).toBe(TEST_API_KEY);
+    expect(config.serverVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  // ─── SPA Fallback ────────────────────────────────────────────────────
+
+  it('falls back to index.html for unknown /dashboard/* paths (SPA routing)', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/some/unknown/route',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('<!DOCTYPE html');
+  });
+
+  // ─── Static Assets ───────────────────────────────────────────────────
+
+  it('serves Next.js static chunks under /dashboard/_next/', async () => {
+    // Get the index.html to find an actual chunk filename
+    const indexRes = await server.app.inject({
+      method: 'GET',
+      url: '/dashboard/',
+    });
+
+    // Extract a JS filename from the HTML
+    const jsMatch = indexRes.body.match(/\/_next\/static\/[^"]+\.js/);
+    expect(jsMatch).not.toBeNull();
+
+    // The HTML references paths with basePath stripped (/_next/...),
+    // but static serving is under /dashboard/ prefix
+    const jsPath = '/dashboard' + jsMatch![0];
+    const jsRes = await server.app.inject({
+      method: 'GET',
+      url: jsPath,
+    });
+
+    expect(jsRes.statusCode).toBe(200);
+    expect(jsRes.headers['content-type']).toContain('javascript');
+  });
+
+  // ─── Non-dashboard Paths ─────────────────────────────────────────────
+
+  it('returns 404 for non-dashboard paths (with auth)', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/nonexistent',
+      headers: {
+        authorization: `Bearer ${TEST_API_KEY}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: 'Not found' });
+  });
+
+  it('returns 401 for non-dashboard paths without auth', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/nonexistent',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('health endpoint still works alongside dashboard', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('ok');
+  });
+
+  // ─── API Routes Still Work ───────────────────────────────────────────
+
+  it('API routes still work with dashboard enabled', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/api/agents',
+      headers: {
+        authorization: `Bearer ${TEST_API_KEY}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.agents).toBeDefined();
+  });
+
+  it('public API keys endpoint works', async () => {
+    const res = await server.app.inject({
+      method: 'GET',
+      url: '/api/api-keys',
+      headers: {
+        authorization: `Bearer ${TEST_API_KEY}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.keys).toBeDefined();
+    expect(Array.isArray(body.keys)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/sandbox-env.test.ts
+++ b/packages/server/src/__tests__/sandbox-env.test.ts
@@ -5,6 +5,11 @@ import { SANDBOX_ENV_ALLOWLIST } from '@ash-ai/shared';
  * Security invariant: sandbox processes must NOT receive host secrets.
  * The allowlist is the enforcement mechanism — test that it doesn't
  * contain dangerous keys, and that the manager respects it.
+ *
+ * NOTE: AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+ * are intentionally NOT in the allowlist. They are injected explicitly via extraEnv
+ * when a Bedrock credential is used. CLAUDE_CODE_USE_BEDROCK is in the allowlist
+ * because it's a feature flag (not a secret).
  */
 describe('sandbox environment isolation', () => {
   const DANGEROUS_KEYS = [
@@ -37,6 +42,7 @@ describe('sandbox environment isolation', () => {
     const expected = new Set([
       'PATH', 'NODE_PATH', 'HOME', 'LANG', 'TERM',
       'ANTHROPIC_API_KEY', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_CUSTOM_HEADERS',
+      'CLAUDE_CODE_USE_BEDROCK',
       'ASH_DEBUG_TIMING', 'ASH_REAL_SDK', 'ASH_PERMISSION_MODE',
       'CLAUDE_CODE_EXECUTABLE',
       'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_SERVICE_NAME',

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -51,7 +51,7 @@ export function registerAuth(app: FastifyInstance, apiKey: string | undefined, d
 
   app.addHook('onRequest', async (request: FastifyRequest, reply) => {
     // Public endpoints — no auth required
-    if (request.url === '/health' || request.url.startsWith('/docs')) {
+    if (request.url === '/health' || request.url.startsWith('/docs') || request.url.startsWith('/dashboard')) {
       request.tenantId = 'default';
       return;
     }

--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { generateApiKey, hashApiKey } from '../auth.js';
-import { insertApiKey } from '../db/index.js';
+import { insertApiKey, listApiKeysByTenant, deleteApiKey } from '../db/index.js';
 
 const internalSecret = process.env.ASH_INTERNAL_SECRET;
 
@@ -33,11 +33,12 @@ function validateInternalAuth(req: FastifyRequest, reply: FastifyReply): boolean
 }
 
 /**
- * Internal endpoint for provisioning per-tenant API keys.
- * Called by the platform to lazily create Ash API keys for each tenant.
- * Protected by ASH_INTERNAL_SECRET when set.
+ * API key management routes.
+ * - Internal endpoint for platform provisioning (protected by ASH_INTERNAL_SECRET)
+ * - Public endpoints for dashboard API key management (protected by normal auth)
  */
 export function apiKeyRoutes(app: FastifyInstance): void {
+  // Internal: platform provisioning
   app.post('/api/internal/api-keys', async (req, reply) => {
     if (!validateInternalAuth(req, reply)) return;
 
@@ -54,5 +55,43 @@ export function apiKeyRoutes(app: FastifyInstance): void {
     const record = await insertApiKey(id, tenantId, keyHash, label || `platform-${tenantId}`);
 
     return reply.send({ id: record.id, key: plainKey, tenantId: record.tenantId });
+  });
+
+  // Public: list API keys for current tenant (key hash hidden)
+  app.get('/api/api-keys', async (req, reply) => {
+    const tenantId = (req as any).tenantId || 'default';
+    const keys = await listApiKeysByTenant(tenantId);
+    return reply.send({
+      keys: keys.map((k) => ({
+        id: k.id,
+        label: k.label,
+        keyPrefix: k.keyHash?.slice(0, 12) ? '••••••••' : undefined,
+        createdAt: k.createdAt,
+      })),
+    });
+  });
+
+  // Public: create a new API key
+  app.post('/api/api-keys', async (req, reply) => {
+    const tenantId = (req as any).tenantId || 'default';
+    const { label } = (req.body || {}) as { label?: string };
+
+    const plainKey = generateApiKey();
+    const hmacSecret = process.env.ASH_CREDENTIAL_KEY;
+    const keyHash = hashApiKey(plainKey, hmacSecret);
+    const id = randomUUID();
+
+    const record = await insertApiKey(id, tenantId, keyHash, label || 'dashboard-key');
+    return reply.status(201).send({ id: record.id, key: plainKey });
+  });
+
+  // Public: revoke an API key
+  app.delete('/api/api-keys/:id', async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const deleted = await deleteApiKey(id);
+    if (!deleted) {
+      return reply.status(404).send({ error: 'API key not found' });
+    }
+    return reply.status(204).send();
   });
 }

--- a/packages/server/src/routes/credentials.ts
+++ b/packages/server/src/routes/credentials.ts
@@ -13,7 +13,7 @@ export function credentialRoutes(app: FastifyInstance): void {
       body: {
         type: 'object',
         properties: {
-          type: { type: 'string', enum: ['anthropic', 'openai', 'custom'] },
+          type: { type: 'string', enum: ['anthropic', 'openai', 'bedrock', 'custom'] },
           key: { type: 'string', minLength: 1 },
           label: { type: 'string' },
         },

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -156,8 +156,31 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
         span.setStatus({ code: SpanStatusCode.ERROR, message: 'Invalid credential' });
         return reply.status(400).send({ error: 'Invalid or inaccessible credential', statusCode: 400 });
       }
-      const envKey = cred.type === 'anthropic' ? 'ANTHROPIC_API_KEY' : cred.type === 'openai' ? 'OPENAI_API_KEY' : 'ASH_CUSTOM_API_KEY';
-      extraEnv = { ...extraEnv, [envKey]: cred.key };
+      if (cred.type === 'bedrock') {
+        // Bedrock credentials are stored as JSON: { accessKeyId, secretAccessKey, region, sessionToken? }
+        let bedrock: { accessKeyId: string; secretAccessKey: string; region: string; sessionToken?: string };
+        try {
+          bedrock = JSON.parse(cred.key);
+        } catch {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: 'Invalid bedrock credential format' });
+          return reply.status(400).send({ error: 'Bedrock credential must be a JSON object with accessKeyId, secretAccessKey, and region', statusCode: 400 });
+        }
+        if (!bedrock.accessKeyId || !bedrock.secretAccessKey || !bedrock.region) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: 'Missing bedrock credential fields' });
+          return reply.status(400).send({ error: 'Bedrock credential requires accessKeyId, secretAccessKey, and region', statusCode: 400 });
+        }
+        extraEnv = {
+          ...extraEnv,
+          CLAUDE_CODE_USE_BEDROCK: '1',
+          AWS_ACCESS_KEY_ID: bedrock.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: bedrock.secretAccessKey,
+          AWS_REGION: bedrock.region,
+          ...(bedrock.sessionToken && { AWS_SESSION_TOKEN: bedrock.sessionToken }),
+        };
+      } else {
+        const envKey = cred.type === 'anthropic' ? 'ANTHROPIC_API_KEY' : cred.type === 'openai' ? 'OPENAI_API_KEY' : 'ASH_CUSTOM_API_KEY';
+        extraEnv = { ...extraEnv, [envKey]: cred.key };
+      }
       touchCredentialUsed(credentialId).catch(() => {});
     }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -3,8 +3,13 @@ import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
 import rateLimit from '@fastify/rate-limit';
 import cors from '@fastify/cors';
-import { join, resolve } from 'node:path';
+import fastifyStatic from '@fastify/static';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { existsSync, writeFileSync } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 import { DEFAULT_PORT, DEFAULT_HOST, DEFAULT_DATA_DIR, DEFAULT_MAX_SANDBOXES, DEFAULT_IDLE_TIMEOUT_MS } from '@ash-ai/shared';
 import { initDb, closeDb, updateSessionStatus, getAgent, getSession, insertSession, updateSessionRunner, listAgents, listApiKeysByTenant, insertApiKey, bulkPauseActiveSessions } from './db/index.js';
 import { QueueProcessor } from './queue/processor.js';
@@ -133,10 +138,10 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
 
   const app = Fastify({ logger: true });
 
-  // CORS — reject cross-origin by default; allow origins from ALLOWED_ORIGINS env
+  // CORS — allow all origins by default (self-hosted tool); restrict via ALLOWED_ORIGINS env
   const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean);
   await app.register(cors, {
-    origin: allowedOrigins && allowedOrigins.length > 0 ? allowedOrigins : false,
+    origin: allowedOrigins && allowedOrigins.length > 0 ? allowedOrigins : true,
     credentials: true,
   });
 
@@ -226,6 +231,44 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
   healthRoutes(app, coordinator, pool);
   runnerRoutes(app, coordinator);
   apiKeyRoutes(app);
+
+  // Dashboard config endpoint — always registered so the dev proxy can reach it.
+  // Includes serverUrl so the dashboard SDK client talks directly to the Ash server,
+  // bypassing the Next.js dev proxy (which breaks SSE streams).
+  app.get('/dashboard/config.js', (req, reply) => {
+    const proto = req.headers['x-forwarded-proto'] || 'http';
+    const host = req.headers['x-forwarded-host'] || req.headers.host || `localhost:${port}`;
+    const serverUrl = `${proto}://${host}`;
+    const config = JSON.stringify({
+      apiKey: opts.apiKey || null,
+      serverVersion: VERSION,
+      serverUrl,
+    });
+    reply.type('application/javascript').send(`window.__ASH_CONFIG__ = ${config};`);
+  });
+
+  // Dashboard static file serving
+  const dashboardEnabled = process.env.ASH_DASHBOARD_ENABLED !== 'false';
+  const dashboardPath = process.env.ASH_DASHBOARD_PATH
+    || join(__dirname, '..', '..', 'dashboard', 'out');
+
+  if (dashboardEnabled && existsSync(dashboardPath)) {
+    await app.register(fastifyStatic, {
+      root: dashboardPath,
+      prefix: '/dashboard/',
+    });
+
+    // SPA fallback: serve index.html for any unmatched /dashboard/* path
+    app.setNotFoundHandler((req, reply) => {
+      if (req.url.startsWith('/dashboard')) {
+        return reply.sendFile('index.html', dashboardPath);
+      }
+      return reply.code(404).send({ error: 'Not found' });
+    });
+
+    app.log.info(`Dashboard available at /dashboard/`);
+    app.log.warn('The dashboard has no authentication. If exposed to a network, place behind an authenticating reverse proxy.');
+  }
 
   coordinator.startLivenessSweep();
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -50,6 +50,9 @@ export const RUNNER_HEARTBEAT_INTERVAL_MS = 10_000;
 export const RUNNER_LIVENESS_TIMEOUT_MS = 30_000;
 
 // Env vars allowed into sandbox processes (allowlist — nothing else leaks)
+// NOTE: AWS secret keys (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+// are intentionally NOT in this list — they must be injected explicitly via extraEnv
+// or the credential system, never leaked from the host environment.
 export const SANDBOX_ENV_ALLOWLIST = [
   'PATH',
   'NODE_PATH',
@@ -59,6 +62,7 @@ export const SANDBOX_ENV_ALLOWLIST = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_CUSTOM_HEADERS',
+  'CLAUDE_CODE_USE_BEDROCK',
   'ASH_DEBUG_TIMING',
   'ASH_REAL_SDK',
   'ASH_PERMISSION_MODE',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -450,7 +450,7 @@ export interface ListSessionsWithTotalResponse {
 
 // -- Credentials --------------------------------------------------------------
 
-export type CredentialType = 'anthropic' | 'openai' | 'custom';
+export type CredentialType = 'anthropic' | 'openai' | 'bedrock' | 'custom';
 
 export interface Credential {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,58 @@ importers:
         specifier: ^17.3.1
         version: 17.3.1
 
+  packages/dashboard:
+    dependencies:
+      '@ash-ai/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@ash-ai/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@ash-ai/ui':
+        specifier: workspace:*
+        version: link:../ui
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@19.2.4)
+      next:
+        specifier: ^15.3.3
+        version: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^2.6.1
+        version: 2.6.1
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.8
+        version: 4.2.1
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.15
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.3(@types/react@19.2.14)
+      postcss:
+        specifier: ^8.5.4
+        version: 8.5.8
+      tailwindcss:
+        specifier: ^4.1.8
+        version: 4.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -182,6 +234,9 @@ importers:
       '@fastify/rate-limit':
         specifier: ^10.3.0
         version: 10.3.0
+      '@fastify/static':
+        specifier: ^8.1.0
+        version: 8.3.0
       '@fastify/swagger':
         specifier: ^9.7.0
         version: 9.7.0
@@ -2218,6 +2273,9 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
+  '@fastify/static@8.3.0':
+    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+
   '@fastify/static@9.0.0':
     resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
 
@@ -2415,6 +2473,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -5878,6 +5940,10 @@ packages:
       debug:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -5992,6 +6058,12 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -6449,6 +6521,10 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6726,6 +6802,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.468.0:
+    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7281,6 +7362,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-json@8.1.1:
     resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
@@ -12217,6 +12301,15 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
+  '@fastify/static@8.3.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 0.5.4
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 11.1.0
+
   '@fastify/static@9.0.0':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
@@ -12407,6 +12500,8 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.19.15
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -16532,6 +16627,11 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data-encoder@2.1.4: {}
 
   form-data@2.5.5:
@@ -16658,6 +16758,15 @@ snapshots:
       tslib: 2.8.1
 
   glob-to-regexp@0.4.1: {}
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
@@ -17172,6 +17281,10 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -17423,6 +17536,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.468.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:
@@ -18252,6 +18369,8 @@ snapshots:
       p-finally: 1.0.0
 
   p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   package-json@8.1.1:
     dependencies:

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -93,7 +93,7 @@ describe('CLI developer workflow', () => {
   });
 
   it('ash session send — sends a message and gets a response', () => {
-    const out = ash(['session', 'send', sessionId, 'what is 2+2? answer in one word'], { timeout: 60_000 });
+    const out = ash(['session', 'send', '--raw', sessionId, 'what is 2+2? answer in one word'], { timeout: 60_000 });
     expect(out).toContain('[message]');
     expect(out).toContain('[done]');
   }, 60_000);

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -121,20 +121,21 @@ describe('full lifecycle', () => {
     const text = await msgRes.text();
 
     // Should contain SSE events
-    expect(text).toContain('event: message');
+    expect(text).toContain('event: session_start');
     expect(text).toContain('event: done');
 
     // Message data should contain SDK-shaped objects
     const dataLines = text.split('\n').filter((l) => l.startsWith('data: '));
     expect(dataLines.length).toBeGreaterThan(0);
 
-    // Parse first data line — should be an SDK assistant message
+    // Parse first data line — should be session_start envelope
     const firstData = JSON.parse(dataLines[0].slice(6));
-    expect(firstData.type).toBe('assistant');
+    expect(firstData.sessionId).toBeTruthy();
   }, 15_000);
 
   it('rejects message to nonexistent session', async () => {
-    const res = await fetch(`${server.url}/api/sessions/ghost/messages`, {
+    // Use a valid UUID format — Fastify schema validation rejects non-UUIDs with 400
+    const res = await fetch(`${server.url}/api/sessions/00000000-0000-0000-0000-000000000000/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...auth },
       body: JSON.stringify({ content: 'hello' }),

--- a/test/integration/python-sdk.test.ts
+++ b/test/integration/python-sdk.test.ts
@@ -37,18 +37,27 @@ function isHttpxAvailable(): boolean {
 }
 
 /**
- * Run a Python script inline, with PYTHONPATH set to include the SDK.
+ * Run a Python script via temp file, with PYTHONPATH set to include the SDK.
  * Returns stdout as a string.
+ *
+ * Using a temp file avoids shell escaping issues with `python3 -c`
+ * (JSON.stringify produces literal \n which the shell doesn't convert).
  */
 function runPython(script: string, env?: Record<string, string>): string {
-  return execSync(`python3 -c ${JSON.stringify(script)}`, {
-    env: {
-      ...process.env,
-      PYTHONPATH: sdkPythonPath,
-      ...env,
-    },
-    timeout: 30_000,
-  }).toString().trim();
+  const scriptPath = join(tmpdir(), `ash-pytest-${Date.now()}-${Math.random().toString(36).slice(2)}.py`);
+  writeFileSync(scriptPath, script);
+  try {
+    return execSync(`python3 ${scriptPath}`, {
+      env: {
+        ...process.env,
+        PYTHONPATH: sdkPythonPath,
+        ...env,
+      },
+      timeout: 30_000,
+    }).toString().trim();
+  } finally {
+    try { rmSync(scriptPath); } catch { /* best effort cleanup */ }
+  }
 }
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary
- **Dashboard**: New `packages/dashboard` — Next.js static-export admin UI with pages for sessions, agents, queue, logs, analytics, playground, and settings (API keys + credentials). Served at `/dashboard/` by the Ash server via `@fastify/static`.
- **Bedrock credentials**: New `bedrock` credential type that stores AWS credentials as encrypted JSON and injects `CLAUDE_CODE_USE_BEDROCK` + AWS env vars into sandbox sessions.
- **SDK improvements**: `AshApiError` class preserving HTTP status codes, `storeBedrockCredential()` helper, `CredentialType` export.
- **API key management**: Public list/create/revoke routes for dashboard use.
- **CORS**: Default to allow all origins (self-hosted tool).
- **Test fixes**: Updated SSE event assertions, Python SDK shell escaping, CLI `--raw` flag.

## Test plan
- [ ] `pnpm test` passes (unit tests including new bedrock-credential and dashboard tests)
- [ ] Dashboard loads at `/dashboard/` when server starts with built output
- [ ] Bedrock credential can be stored and used to create a session
- [ ] API key CRUD works from dashboard
- [ ] Integration tests pass with updated SSE assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)