### PR TITLE
release: @ash-ai/server v0.0.32, @ash-ai/sdk v0.0.21, @ash-ai/shared v0.0.21

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.20 - 2026-03-10
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21
+
 ## 0.0.19 - 2026-03-06
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.22 - 2026-03-10
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21, @ash-ai/sdk@0.0.21
+
 ## 0.0.21 - 2026-03-07
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.17 - 2026-03-10
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21, @ash-ai/sdk@0.0.21
+
 ## 0.0.16 - 2026-03-06
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.20 - 2026-03-10
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21, @ash-ai/sandbox@0.0.26
+
 ## 0.0.19 - 2026-03-06
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.26 - 2026-03-10
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21
+
 ## 0.0.25 - 2026-03-06
 
 ### Added

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.21 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.20 - 2026-03-06
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.20"
+version = "0.0.21"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ash-ai/sdk
 
+## 0.0.21 - 2026-03-10
+
+### Added
+
+- `AshApiError` class preserving HTTP status codes on API errors (#72)
+- `storeBedrockCredential()` convenience method for storing AWS Bedrock credentials (#72)
+- Export `CredentialType` from `@ash-ai/shared` (#72)
+
+### Changed
+
+- Updated dependencies: @ash-ai/shared@0.0.21
+
 ## 0.0.20 - 2026-03-06
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @ash-ai/server
 
+## 0.0.32 - 2026-03-10
+
+### Added
+
+- Dashboard UI served at `/dashboard/` via `@fastify/static` with SPA fallback and dynamic `config.js` endpoint (#72)
+- Bedrock credential support: store AWS credentials as encrypted JSON, inject `CLAUDE_CODE_USE_BEDROCK` + AWS env vars into sandbox sessions (#72)
+- Public API key management routes: list, create, and revoke API keys (#72)
+- `CLAUDE_CODE_USE_BEDROCK` added to sandbox env allowlist (#72)
+
+### Changed
+
+- CORS defaults to allow all origins (self-hosted tool); restrict via `ALLOWED_ORIGINS` env (#72)
+- Dashboard routes (`/dashboard/*`) bypass API key authentication (#72)
+- Updated dependencies: @ash-ai/shared@0.0.21
+
 ## 0.0.31
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/shared
 
+## 0.0.21 - 2026-03-10
+
+### Added
+
+- `bedrock` credential type (#72)
+- `CLAUDE_CODE_USE_BEDROCK` in sandbox env allowlist (#72)
+
 ## 0.0.20 - 2026-03-06
 
 ### Changed

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.16 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.15 - 2026-03-06
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
Patch release for dashboard, Bedrock credentials, and SDK improvements.

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/shared | 0.0.20 | 0.0.21 |
| @ash-ai/bridge | 0.0.19 | 0.0.20 |
| @ash-ai/cli | 0.0.21 | 0.0.22 |
| @ash-ai/sandbox | 0.0.25 | 0.0.26 |
| @ash-ai/server | 0.0.31 | 0.0.32 |
| @ash-ai/runner | 0.0.19 | 0.0.20 |
| @ash-ai/sdk | 0.0.20 | 0.0.21 |
| @ash-ai/mcp-server | 0.0.16 | 0.0.17 |
| @ash-ai/ui | 0.0.15 | 0.0.16 |
| ash-ai-sdk | 0.0.20 | 0.0.21 |

## Test plan
- [ ] CI passes
- [ ] Version bumps are correct in package.json files
- [ ] CHANGELOGs accurately describe changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)