### PR TITLE
Make @ash-ai/dashboard a public package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Build output
 dist/
+out/
 *.tsbuildinfo
 .next/
 

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @ash-ai/dashboard
+
+## 0.0.1 - 2026-03-10
+
+### Added
+
+- Initial release: Next.js static-export admin dashboard (#72)
+- Pages: sessions, agents, queue, logs, analytics, playground
+- Settings: API key management, credential management (including Bedrock)
+- Served by Ash server at `/dashboard/` via `@fastify/static`

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@ash-ai/dashboard",
   "version": "0.0.1",
-  "private": true,
+  "files": [
+    "out",
+    "app",
+    "components",
+    "lib",
+    "next.config.ts",
+    "postcss.config.mjs",
+    "tsconfig.json",
+    "package.json"
+  ],
   "scripts": {
     "dev": "next dev --port 4200",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Remove `"private": true` from `@ash-ai/dashboard` so it gets published to npm alongside other packages
- Add `"files"` field to include built `out/` directory in the npm tarball
- Add `out/` to `.gitignore` (build artifact shouldn't be in git)
- Add CHANGELOG.md

## Test plan
- [ ] `pnpm build` still works
- [ ] Dashboard package.json no longer has `private: true`
- [ ] `out/` is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)