### PR TITLE
release: @ash-ai/dashboard v0.0.2

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/bridge
 
+## 0.0.21 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.20 - 2026-03-10
 
 ### Changed

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/bridge",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/cli
 
+## 0.0.23 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.22 - 2026-03-10
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/cli",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ash-ai/dashboard
 
+## 0.0.2 - 2026-03-10
+
+### Changed
+
+- Package is now public (removed `private: true`) (#74)
+- Added `files` field for npm publishing (#74)
+
 ## 0.0.1 - 2026-03-10
 
 ### Added

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/dashboard",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "files": [
     "out",
     "app",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/mcp-server
 
+## 0.0.18 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.17 - 2026-03-10
 
 ### Changed

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/mcp-server",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/runner
 
+## 0.0.21 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.20 - 2026-03-10
 
 ### Changed

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/runner",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sandbox
 
+## 0.0.27 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.26 - 2026-03-10
 
 ### Changed

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sandbox",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ash-ai-sdk (Python)
 
+## 0.0.22 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.21 - 2026-03-10
 
 ### Changed

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ash-ai-sdk"
-version = "0.0.21"
+version = "0.0.22"
 description = "Python SDK for the Ash AI agent orchestration platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/sdk
 
+## 0.0.22 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.21 - 2026-03-10
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/sdk",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/server
 
+## 0.0.33 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.32 - 2026-03-10
 
 ### Added

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/server",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/shared
 
+## 0.0.22 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.21 - 2026-03-10
 
 ### Added

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/shared",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ash-ai/ui
 
+## 0.0.17 - 2026-03-10
+
+### Changed
+
+- Updated dependencies
+
 ## 0.0.16 - 2026-03-10
 
 ### Changed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ash-ai/ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
First public release of `@ash-ai/dashboard`. Previously marked `private: true`, now published to npm.

| Package | Old | New |
|---------|-----|-----|
| @ash-ai/dashboard | 0.0.1 (private) | **0.0.2** (public) |
| @ash-ai/shared | 0.0.21 | 0.0.22 |
| @ash-ai/bridge | 0.0.20 | 0.0.21 |
| @ash-ai/cli | 0.0.22 | 0.0.23 |
| @ash-ai/sandbox | 0.0.26 | 0.0.27 |
| @ash-ai/server | 0.0.32 | 0.0.33 |
| @ash-ai/runner | 0.0.20 | 0.0.21 |
| @ash-ai/sdk | 0.0.21 | 0.0.22 |
| @ash-ai/mcp-server | 0.0.17 | 0.0.18 |
| @ash-ai/ui | 0.0.16 | 0.0.17 |
| ash-ai-sdk | 0.0.21 | 0.0.22 |

## Test plan
- [ ] CI passes
- [ ] `@ash-ai/dashboard` no longer has `private: true`
- [ ] Version bumps correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)