### PR TITLE
fix: dashboard UX — flickering, message rendering, favicon 401, telemetry noise

### DIFF
--- a/.changeset/fix-dashboard-ux.md
+++ b/.changeset/fix-dashboard-ux.md
@@ -1,0 +1,11 @@
+---
+"@ash-ai/server": patch
+"@ash-ai/dashboard": patch
+---
+
+Fix dashboard UX issues: flickering, message rendering, favicon auth, telemetry warnings.
+
+- `@ash-ai/dashboard` — Cache last-known health, agents, and sessions in sessionStorage so the UI doesn't flash OFFLINE/"-" between navigations
+- `@ash-ai/dashboard` — Fix assistant message rendering: extract text from SDK result objects instead of showing raw JSON
+- `@ash-ai/server` — Exclude `/favicon.ico` from auth middleware (was returning 401)
+- `@ash-ai/server` — Suppress repeated telemetry POST warnings for the same HTTP status (e.g. 404 when Cloud endpoint isn't live yet)

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -361,6 +361,24 @@ function MessageBlock({ message }: { message: Message }) {
         .join('\n')
     } else if (typeof parsed === 'string') {
       displayContent = parsed
+    } else if (parsed && typeof parsed === 'object') {
+      // SDK result/assistant messages: extract text from content array or result field
+      const obj = parsed as Record<string, unknown>
+      if (Array.isArray(obj.content)) {
+        const textBlocks = (obj.content as Record<string, unknown>[]).filter(
+          (b) => b.type === 'text'
+        )
+        toolCalls = (obj.content as Record<string, unknown>[]).filter(
+          (b) => b.type === 'tool_use'
+        ) as typeof toolCalls
+        displayContent = textBlocks
+          .map((b) => String(b.text || ''))
+          .join('\n')
+      } else if (typeof obj.result === 'string') {
+        displayContent = obj.result
+      } else if (typeof obj.text === 'string') {
+        displayContent = obj.text
+      }
     } else {
       displayContent = message.content
     }

--- a/packages/dashboard/lib/hooks.ts
+++ b/packages/dashboard/lib/hooks.ts
@@ -20,15 +20,28 @@ function useInterval(callback: () => void, delay: number | null) {
 
 // ─── useAgents ───
 
+function getCached<T>(key: string): T | null {
+  try {
+    const cached = sessionStorage.getItem(key)
+    return cached ? JSON.parse(cached) : null
+  } catch { return null }
+}
+
+function setCache(key: string, data: unknown): void {
+  try { sessionStorage.setItem(key, JSON.stringify(data)) } catch {}
+}
+
 export function useAgents() {
-  const [agents, setAgents] = useState<Agent[]>([])
-  const [loading, setLoading] = useState(true)
+  const cached = getCached<Agent[]>('ash:agents')
+  const [agents, setAgents] = useState<Agent[]>(cached ?? [])
+  const [loading, setLoading] = useState(!cached)
   const [error, setError] = useState<Error | null>(null)
 
   const refetch = useCallback(async () => {
     try {
       const result = await getClient().listAgents()
       setAgents(result)
+      setCache('ash:agents', result)
       setError(null)
     } catch (e) {
       setError(e as Error)
@@ -51,21 +64,24 @@ export function useSessions(opts?: {
   limit?: number
   autoRefresh?: boolean
 }) {
-  const [sessions, setSessions] = useState<Session[]>([])
-  const [loading, setLoading] = useState(true)
+  const cacheKey = `ash:sessions:${opts?.agent ?? 'all'}`
+  const cached = getCached<Session[]>(cacheKey)
+  const [sessions, setSessions] = useState<Session[]>(cached ?? [])
+  const [loading, setLoading] = useState(!cached)
   const [error, setError] = useState<Error | null>(null)
 
   const refetch = useCallback(async () => {
     try {
       const result = await getClient().listSessions(opts?.agent)
       setSessions(result)
+      setCache(cacheKey, result)
       setError(null)
     } catch (e) {
       setError(e as Error)
     } finally {
       setLoading(false)
     }
-  }, [opts?.agent])
+  }, [opts?.agent, cacheKey])
 
   useEffect(() => {
     refetch()
@@ -89,14 +105,16 @@ export interface HealthData {
 }
 
 export function useHealth() {
-  const [health, setHealth] = useState<HealthData | null>(null)
+  const [health, setHealth] = useState<HealthData | null>(() => getCached('ash:health'))
   const [error, setError] = useState<Error | null>(null)
 
   const refetch = useCallback(async () => {
     try {
       const result = await getClient().health()
-      setHealth(result as HealthData)
+      const data = result as HealthData
+      setHealth(data)
       setError(null)
+      setCache('ash:health', data)
     } catch (e) {
       setError(e as Error)
     }

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -51,7 +51,7 @@ export function registerAuth(app: FastifyInstance, apiKey: string | undefined, d
 
   app.addHook('onRequest', async (request: FastifyRequest, reply) => {
     // Public endpoints — no auth required
-    if (request.url === '/health' || request.url.startsWith('/docs') || request.url.startsWith('/dashboard')) {
+    if (request.url === '/health' || request.url === '/favicon.ico' || request.url.startsWith('/docs') || request.url.startsWith('/dashboard')) {
       request.tenantId = 'default';
       return;
     }

--- a/packages/server/src/telemetry/exporter.ts
+++ b/packages/server/src/telemetry/exporter.ts
@@ -31,6 +31,7 @@ class HttpTelemetryExporter implements TelemetryExporter {
   private sequences = new Map<string, number>();
   private timer: ReturnType<typeof setInterval>;
   private instanceId = hostname();
+  private warnedStatuses = new Set<number>();
 
   constructor(
     private url: string,
@@ -88,8 +89,9 @@ class HttpTelemetryExporter implements TelemetryExporter {
         signal: AbortSignal.timeout(10_000),
       });
 
-      if (!res.ok) {
-        console.warn(`[telemetry] POST ${this.url} returned ${res.status}`);
+      if (!res.ok && !this.warnedStatuses.has(res.status)) {
+        this.warnedStatuses.add(res.status);
+        console.warn(`[telemetry] POST ${this.url} returned ${res.status} (suppressing further warnings for this status)`);
       }
     } catch (err) {
       console.warn(`[telemetry] POST failed: ${err}`);


### PR DESCRIPTION
## Summary

Closes #76

- **Dashboard flickering** — Cache last-known health, agents, and sessions state in `sessionStorage`. The ONLINE/OFFLINE indicator and stat cards now retain their previous values between navigations instead of resetting to OFFLINE/"-" while the next poll completes.
- **Message rendering** — Parse SDK result objects (with `content` array, `result` field, or `text` field) instead of showing raw JSON for assistant messages.
- **`/favicon.ico` 401** — Add `/favicon.ico` to the auth middleware's public endpoint list so browsers don't get a 401 on every page load.
- **Telemetry POST noise** — Suppress repeated warnings for the same HTTP status code (e.g. 404 when Cloud telemetry endpoint isn't live yet). Each status is logged once.

Note: The Playground loading state (item 3 in the issue) is a Next.js static export limitation — the playground page requires client-side rendering. A skeleton UI improvement can be done separately.

## Test plan

- [x] `pnpm build` — all packages compile
- [x] All 244 server tests pass (8 pre-existing dashboard static serving failures excluded — those are unrelated to this change)
- [x] Auth tests pass — favicon exclusion doesn't break existing auth behavior
- [ ] Verify dashboard no longer flickers OFFLINE on navigation
- [ ] Verify assistant messages render text instead of raw JSON
- [ ] Verify `/favicon.ico` returns 200 instead of 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)