### PR TITLE
fix: empty user messages + expandable raw JSON in dashboard

### DIFF
--- a/.changeset/fix-dashboard-user-messages.md
+++ b/.changeset/fix-dashboard-user-messages.md
@@ -1,0 +1,8 @@
+---
+"@ash-ai/dashboard": patch
+---
+
+Fix empty user messages and add expandable raw JSON view in session detail.
+
+- Fix user messages appearing empty — user message content stored as `{type: "user", content: "..."}` was not being extracted
+- Add "Raw JSON" toggle to every message for debugging — shows the full JSON payload, system prompt, and metadata

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -374,6 +374,8 @@ function MessageBlock({ message }: { message: Message }) {
         displayContent = textBlocks
           .map((b) => String(b.text || ''))
           .join('\n')
+      } else if (typeof obj.content === 'string') {
+        displayContent = obj.content
       } else if (typeof obj.result === 'string') {
         displayContent = obj.result
       } else if (typeof obj.text === 'string') {
@@ -407,6 +409,20 @@ function MessageBlock({ message }: { message: Message }) {
             <ToolCallDisplay key={tc.id || idx} toolCall={tc} />
           ))}
         </div>
+      )}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="mt-2 text-xs text-white/30 hover:text-white/50 transition-colors flex items-center gap-1"
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        Raw JSON
+      </button>
+      {expanded && (
+        <pre className="mt-2 text-xs text-white/40 overflow-auto max-h-64 bg-black/30 rounded p-3 font-mono">
+          {(() => {
+            try { return JSON.stringify(JSON.parse(message.content), null, 2) } catch { return message.content }
+          })()}
+        </pre>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Closes #79

- **Empty user messages** — User messages are stored as `{"type":"user","content":"Hello"}`. The content parser checked for `obj.content` as an array but not as a string, so the text was never extracted. Fixed by adding `typeof obj.content === 'string'` check.
- **Expandable raw JSON** — Every message now has a "Raw JSON" toggle that reveals the full JSON payload for debugging (metadata, system prompt, tool calls, usage stats, etc.).

Item 3 (polling vs WebSocket) was partially addressed in #77 with sessionStorage caching. Full SSE-based live updates would be a larger architectural change.

## Test plan

- [x] `pnpm build` — compiles
- [x] All 244 server tests pass
- [ ] Verify user messages display their content in session detail view
- [ ] Verify "Raw JSON" toggle shows full payload on both user and assistant messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)