### PR TITLE
fix: show ASH_API_KEY env var in dashboard API Keys page

### DIFF
--- a/.changeset/fix-api-keys-dashboard.md
+++ b/.changeset/fix-api-keys-dashboard.md
@@ -1,0 +1,9 @@
+---
+"@ash-ai/server": patch
+"@ash-ai/dashboard": patch
+---
+
+Show ASH_API_KEY environment variable in dashboard API Keys page.
+
+- `@ash-ai/server` — Include the `ASH_API_KEY` env var as a synthetic entry in `GET /api/api-keys` so the dashboard shows it exists
+- `@ash-ai/dashboard` — Display env var keys with an `env` badge, hide the delete button for them

--- a/packages/dashboard/app/settings/api-keys/page.tsx
+++ b/packages/dashboard/app/settings/api-keys/page.tsx
@@ -193,22 +193,29 @@ export default function ApiKeysPage() {
               <tbody className="divide-y divide-white/5">
                 {keys.map((key) => (
                   <tr key={key.id} className="hover:bg-white/[0.02]">
-                    <td className="px-6 py-3 text-white/80 font-medium">{key.label}</td>
+                    <td className="px-6 py-3 text-white/80 font-medium">
+                      {key.label}
+                      {key.id === 'env' && (
+                        <span className="ml-2 text-xs text-amber-400/60">env</span>
+                      )}
+                    </td>
                     <td className="px-6 py-3 text-white/40 font-mono text-xs">
                       {key.keyPrefix || '••••••••'}
                     </td>
                     <td className="px-6 py-3 text-white/40">
-                      {formatRelativeTime(key.createdAt)}
+                      {key.createdAt ? formatRelativeTime(key.createdAt) : '—'}
                     </td>
                     <td className="px-6 py-3 text-right">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleRevoke(key.id)}
-                        className="text-red-400 hover:text-red-300"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
+                      {key.id !== 'env' && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleRevoke(key.id)}
+                          className="text-red-400 hover:text-red-300"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -37,7 +37,7 @@ function validateInternalAuth(req: FastifyRequest, reply: FastifyReply): boolean
  * - Internal endpoint for platform provisioning (protected by ASH_INTERNAL_SECRET)
  * - Public endpoints for dashboard API key management (protected by normal auth)
  */
-export function apiKeyRoutes(app: FastifyInstance): void {
+export function apiKeyRoutes(app: FastifyInstance, envApiKey?: string): void {
   // Internal: platform provisioning
   app.post('/api/internal/api-keys', async (req, reply) => {
     if (!validateInternalAuth(req, reply)) return;
@@ -61,14 +61,25 @@ export function apiKeyRoutes(app: FastifyInstance): void {
   app.get('/api/api-keys', async (req, reply) => {
     const tenantId = (req as any).tenantId || 'default';
     const keys = await listApiKeysByTenant(tenantId);
-    return reply.send({
-      keys: keys.map((k) => ({
-        id: k.id,
-        label: k.label,
-        keyPrefix: k.keyHash?.slice(0, 12) ? '••••••••' : undefined,
-        createdAt: k.createdAt,
-      })),
-    });
+    const result = keys.map((k) => ({
+      id: k.id,
+      label: k.label,
+      keyPrefix: k.keyHash?.slice(0, 12) ? '••••••••' : undefined,
+      createdAt: k.createdAt,
+    }));
+
+    // Include the ASH_API_KEY env var as a synthetic entry so the dashboard
+    // shows that an environment-configured key exists (issue #82).
+    if (envApiKey && tenantId === 'default') {
+      result.unshift({
+        id: 'env',
+        label: 'ASH_API_KEY (environment variable)',
+        keyPrefix: envApiKey.slice(0, 8) + '••••',
+        createdAt: '',
+      });
+    }
+
+    return reply.send({ keys: result });
   });
 
   // Public: create a new API key

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -230,7 +230,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
   workspaceRoutes(app, coordinator, dataDir);
   healthRoutes(app, coordinator, pool);
   runnerRoutes(app, coordinator);
-  apiKeyRoutes(app);
+  apiKeyRoutes(app, opts.apiKey);
 
   // Dashboard config endpoint — always registered so the dev proxy can reach it.
   // Includes serverUrl so the dashboard SDK client talks directly to the Ash server,

--- a/website/docs/self-hosting/configuration.md
+++ b/website/docs/self-hosting/configuration.md
@@ -93,7 +93,7 @@ Ash supports two authentication modes:
 
 ### Auto-Generated Key (Default)
 
-When `ASH_API_KEY` is not set, the server auto-generates a secure API key on first start. The key is stored (hashed) in the database and the plaintext is written to `{ASH_DATA_DIR}/initial-api-key`. The CLI automatically picks up this key via `ash start`.
+When `ASH_API_KEY` is not set, the server auto-generates a secure API key on first start. The key is stored (hashed) in the database and the plaintext is written to `{ASH_DATA_DIR}/initial-api-key`. The CLI automatically picks up this key via `ash start`. This key appears in the dashboard's **API Keys** page and can be revoked there.
 
 ### Explicit API Key
 
@@ -109,7 +109,13 @@ All API requests must then include:
 Authorization: Bearer my-secret-key
 ```
 
-For multi-tenant authentication, create API keys via the database. Each key is associated with a `tenant_id`, and requests authenticated with that key are scoped to that tenant's agents, sessions, and data.
+The environment variable key is shown in the dashboard's **API Keys** page with an `env` badge. To change or remove it, update the environment variable and restart the server.
+
+### Dashboard-Created Keys
+
+You can also create additional API keys directly from the dashboard's **API Keys** page. These keys are stored in the database and can be revoked from the dashboard. Both environment-variable and dashboard-created keys work simultaneously.
+
+For multi-tenant authentication, create API keys via the internal API. Each key is associated with a `tenant_id`, and requests authenticated with that key are scoped to that tenant's agents, sessions, and data.
 
 ### Public Endpoints
 


### PR DESCRIPTION
## Summary

Closes #82

### Issue 1: ASH_API_KEY purpose unclear

Updated the [Configuration Reference](https://docs.ash-cloud.ai/self-hosting/configuration#authentication) to clearly explain the three auth modes:
- **Auto-generated** (default) — key is created on first start, stored in DB, written to `initial-api-key` file, visible in dashboard
- **Explicit env var** — `ASH_API_KEY=...` sets a specific key, now visible in dashboard with `env` badge
- **Dashboard-created** — additional keys created from the API Keys page, stored in DB, revocable

### Issue 2: Keys not reflected in dashboard

The `ASH_API_KEY` env var was checked directly in the auth middleware but never inserted into the `api_keys` DB table, so the dashboard's API Keys page showed "No API keys yet" even when auth was working.

**Fix**: The `GET /api/api-keys` endpoint now includes the env var key as a synthetic entry (id=`env`, label=`ASH_API_KEY (environment variable)`, prefix shown). The dashboard renders it with an `env` badge and no delete button — to change it, update the env var and restart.

## Test plan

- [x] `pnpm build` — compiles
- [x] All 244 server tests pass
- [ ] Verify `ASH_API_KEY` env var appears in dashboard API Keys page
- [ ] Verify env var key cannot be deleted from dashboard
- [ ] Verify dashboard-created keys still work alongside env var key

🤖 Generated with [Claude Code](https://claude.com/claude-code)