### PR TITLE
fix: stop dashboard polling tight loop for non-active sessions

### DIFF
--- a/.changeset/fix-dashboard-polling.md
+++ b/.changeset/fix-dashboard-polling.md
@@ -1,0 +1,10 @@
+---
+"@ash-ai/dashboard": patch
+---
+
+Fix dashboard polling tight loop when viewing completed/paused sessions.
+
+- Remove `setLoadingData(true)` from subsequent fetches — only show loading shimmer on initial load, preventing re-render cascades
+- Add fetch-in-flight guard (`fetchingRef`) to prevent concurrent duplicate requests
+- Extract `sessionId`/`sessionStatus` as stable primitive values for `useCallback`/`useEffect` dependencies
+- Add `key={session.id}` to `SessionDetail` for clean state reset when switching sessions

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -141,7 +141,7 @@ function SessionsPageInner() {
       {/* Right: Detail */}
       <div className="flex-1 min-w-0">
         {selectedSession ? (
-          <SessionDetail session={selectedSession} />
+          <SessionDetail key={selectedSession.id} session={selectedSession} />
         ) : (
           <EmptyState
             icon={<Activity className="h-12 w-12" />}
@@ -162,41 +162,47 @@ function SessionDetail({ session }: { session: Session }) {
   const [events, setEvents] = useState<SessionEvent[]>([])
   const [logs, setLogs] = useState<string[]>([])
   const [loadingData, setLoadingData] = useState(true)
+  const fetchingRef = useRef(false)
+  const sessionId = session.id
+  const sessionStatus = session.status
 
   const fetchData = useCallback(async () => {
-    setLoadingData(true)
+    if (fetchingRef.current) return
+    fetchingRef.current = true
     try {
       const client = getClient()
       const [msgs, evts] = await Promise.all([
-        client.listMessages(session.id).catch(() => []),
-        client.listSessionEvents(session.id).catch(() => []),
+        client.listMessages(sessionId).catch(() => []),
+        client.listSessionEvents(sessionId).catch(() => []),
       ])
       setMessages(msgs)
       setEvents(evts)
     } catch {
       // Silently handle errors
     } finally {
+      fetchingRef.current = false
       setLoadingData(false)
     }
-  }, [session.id])
+  }, [sessionId])
 
+  // Initial fetch only
   useEffect(() => {
     fetchData()
   }, [fetchData])
 
-  // Auto-refresh for active sessions
+  // Auto-refresh for active sessions only
   useEffect(() => {
-    if (session.status !== 'active') return
+    if (sessionStatus !== 'active') return
     const interval = setInterval(fetchData, 5000)
     return () => clearInterval(interval)
-  }, [session.status, fetchData])
+  }, [sessionStatus, fetchData])
 
   // Fetch logs when terminal tab is selected
   useEffect(() => {
     if (tab !== 'terminal') return
     const fetchLogs = async () => {
       try {
-        const result = await getClient().getSessionLogs(session.id)
+        const result = await getClient().getSessionLogs(sessionId)
         if (result?.logs) {
           setLogs(result.logs.map((l) => l.text))
         }
@@ -205,19 +211,19 @@ function SessionDetail({ session }: { session: Session }) {
       }
     }
     fetchLogs()
-    if (session.status === 'active') {
+    if (sessionStatus === 'active') {
       const interval = setInterval(fetchLogs, 2000)
       return () => clearInterval(interval)
     }
-  }, [tab, session.id, session.status])
+  }, [tab, sessionId, sessionStatus])
 
   async function handleAction(action: 'pause' | 'resume' | 'stop' | 'end') {
     const client = getClient()
     try {
-      if (action === 'pause') await client.pauseSession(session.id)
-      else if (action === 'resume') await client.resumeSession(session.id)
-      else if (action === 'stop') await client.stopSession(session.id)
-      else if (action === 'end') await client.endSession(session.id)
+      if (action === 'pause') await client.pauseSession(sessionId)
+      else if (action === 'resume') await client.resumeSession(sessionId)
+      else if (action === 'stop') await client.stopSession(sessionId)
+      else if (action === 'end') await client.endSession(sessionId)
     } catch (e) {
       console.error(`Failed to ${action} session:`, e)
     }


### PR DESCRIPTION
## Summary

- Remove `setLoadingData(true)` from subsequent fetches — only show loading shimmer on initial load, preventing re-render cascades that could trigger rapid re-fetching
- Add `fetchingRef` guard to prevent concurrent duplicate API requests (messages + events)
- Extract `sessionId`/`sessionStatus` as stable primitive values for `useCallback`/`useEffect` dependencies instead of referencing the session object directly
- Add `key={session.id}` to `SessionDetail` so React properly resets component state when switching between sessions

## Root cause

`SessionDetail.fetchData` called `setLoadingData(true)` on every invocation (including interval-triggered re-fetches), causing a state update → re-render on every poll cycle. Combined with the parent component's `useSessions` polling (which produces new session object references via `sessions.find()`), this could cascade into rapid re-rendering and duplicate fetches. For non-active sessions, the auto-refresh interval was correctly gated (`if (session.status !== 'active') return`), but the `setLoadingData` re-render could still trigger unnecessary work.

Closes #85

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (257 tests)
- [ ] Manually verify: view a paused/ended session → Network tab shows only the initial messages+events fetch, no repeated polling
- [ ] Manually verify: view an active session → messages+events refresh every 5s (not faster)
- [ ] Manually verify: switching sessions resets the detail view (loading shimmer, then data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)