### PR TITLE
feat: agent versioning, eval framework, and knowledge base management

### DIFF
--- a/.changeset/agent-versioning-evals.md
+++ b/.changeset/agent-versioning-evals.md
@@ -1,0 +1,7 @@
+---
+"@ash-ai/shared": minor
+"@ash-ai/server": minor
+"@ash-ai/sdk": minor
+---
+
+Add agent versioning, eval framework, and knowledge base file management.

--- a/packages/dashboard/app/agents/detail/page.tsx
+++ b/packages/dashboard/app/agents/detail/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import {
+  ArrowLeft,
+  Bot,
+  GitBranch,
+  BookOpen,
+  FlaskConical,
+  FolderOpen,
+  Clock,
+} from 'lucide-react'
+import type { Agent } from '@ash-ai/shared'
+
+function AgentDetailContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const [agent, setAgent] = useState<Agent | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!name) {
+      setLoading(false)
+      return
+    }
+    async function fetchAgent() {
+      try {
+        const agents = await getClient().listAgents()
+        const found = agents.find((a) => a.name === name)
+        if (found) {
+          setAgent(found)
+        } else {
+          setError(`Agent "${name}" not found`)
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to fetch agent')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchAgent()
+  }, [name])
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <ShimmerBlock height={80} />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={120} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !agent) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-red-400">{error || 'Agent not found'}</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  const tabs = [
+    {
+      label: 'Versions',
+      href: `/agents/versions?name=${encodeURIComponent(agent.name)}`,
+      icon: GitBranch,
+      description: 'Manage agent versions and system prompts',
+    },
+    {
+      label: 'Knowledge',
+      href: `/agents/knowledge?name=${encodeURIComponent(agent.name)}`,
+      icon: BookOpen,
+      description: 'Upload and manage knowledge base files',
+    },
+    {
+      label: 'Evals',
+      href: `/agents/evals?name=${encodeURIComponent(agent.name)}`,
+      icon: FlaskConical,
+      description: 'Define and run evaluation test cases',
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/agents"
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to agents
+      </Link>
+
+      {/* Agent header */}
+      <Card>
+        <CardContent>
+          <div className="flex items-start gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-indigo-500/10">
+              <Bot className="h-6 w-6 text-indigo-400" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h1 className="text-xl font-bold text-white">{agent.name}</h1>
+              {agent.description && (
+                <p className="mt-1 text-sm text-white/50">{agent.description}</p>
+              )}
+              <div className="flex flex-wrap items-center gap-3 mt-3">
+                {agent.model && <Badge variant="info">{agent.model}</Badge>}
+                {agent.status && (
+                  <Badge variant={agent.status === 'active' ? 'success' : 'default'}>
+                    {agent.status}
+                  </Badge>
+                )}
+                {agent.path && (
+                  <span className="inline-flex items-center gap-1 text-xs text-white/30">
+                    <FolderOpen className="h-3 w-3" />
+                    {agent.path}
+                  </span>
+                )}
+                {agent.createdAt && (
+                  <span className="inline-flex items-center gap-1 text-xs text-white/30">
+                    <Clock className="h-3 w-3" />
+                    Created {formatRelativeTime(agent.createdAt)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tab cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {tabs.map((tab) => (
+          <Link key={tab.label} href={tab.href}>
+            <Card className="hover:border-white/20 hover:bg-white/[0.02] transition-all cursor-pointer h-full">
+              <CardContent>
+                <div className="flex items-center gap-3 mb-2">
+                  <tab.icon className="h-5 w-5 text-indigo-400" />
+                  <h3 className="text-sm font-semibold text-white">{tab.label}</h3>
+                </div>
+                <p className="text-xs text-white/40">{tab.description}</p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function AgentDetailPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <AgentDetailContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/eval-compare/page.tsx
+++ b/packages/dashboard/app/agents/eval-compare/page.tsx
@@ -1,0 +1,445 @@
+'use client'
+
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime, truncateId } from '@/lib/utils'
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  ArrowDownRight,
+  Minus,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react'
+import type { EvalRunComparison } from '@ash-ai/shared'
+
+function scoreColor(score: number | null): string {
+  if (score === null) return 'text-white/30'
+  if (score >= 0.8) return 'text-green-400'
+  if (score >= 0.5) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+function DiffIndicator({ a, b }: { a: number | null; b: number | null }) {
+  if (a === null || b === null) return <Minus className="h-3 w-3 text-white/20" />
+  const diff = b - a
+  if (Math.abs(diff) < 0.01) return <Minus className="h-3 w-3 text-white/30" />
+  if (diff > 0) return <ArrowUpRight className="h-3 w-3 text-green-400" />
+  return <ArrowDownRight className="h-3 w-3 text-red-400" />
+}
+
+function diffValue(a: number | null, b: number | null): string {
+  if (a === null || b === null) return '--'
+  const diff = b - a
+  const sign = diff >= 0 ? '+' : ''
+  return `${sign}${diff.toFixed(2)}`
+}
+
+function diffColor(a: number | null, b: number | null): string {
+  if (a === null || b === null) return 'text-white/30'
+  const diff = b - a
+  if (Math.abs(diff) < 0.01) return 'text-white/30'
+  return diff > 0 ? 'text-green-400' : 'text-red-400'
+}
+
+function EvalCompareContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const runA = searchParams.get('runA')
+  const runB = searchParams.get('runB')
+
+  const [comparison, setComparison] = useState<EvalRunComparison | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedCase, setExpandedCase] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!name || !runA || !runB) {
+      setLoading(false)
+      return
+    }
+    async function fetchComparison() {
+      try {
+        const data = await getClient().compareEvalRuns(name!, runA!, runB!)
+        setComparison(data)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load comparison')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchComparison()
+  }, [name, runA, runB])
+
+  if (!name || !runA || !runB) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">Missing comparison parameters.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <ShimmerBlock height={120} />
+        <ShimmerBlock height={200} />
+      </div>
+    )
+  }
+
+  if (error || !comparison) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-red-400">{error || 'Failed to load comparison'}</p>
+        <Link
+          href={`/agents/eval-runs?name=${encodeURIComponent(name)}`}
+          className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block"
+        >
+          Back to eval runs
+        </Link>
+      </div>
+    )
+  }
+
+  const { runA: metaA, runB: metaB, results } = comparison
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/eval-runs?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to eval runs
+      </Link>
+
+      <h1 className="text-2xl font-bold text-white">Run Comparison</h1>
+
+      {/* Summary Comparison */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {/* Run A */}
+        <Card>
+          <CardContent>
+            <div className="text-xs text-white/40 mb-2">Run A</div>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-sm font-semibold text-white">{truncateId(metaA.id)}</span>
+              {metaA.versionNumber !== null && metaA.versionNumber !== undefined && (
+                <Badge variant="default">v{metaA.versionNumber}</Badge>
+              )}
+            </div>
+            <div className="text-xs text-white/30">{formatRelativeTime(metaA.createdAt)}</div>
+            {metaA.summary && (
+              <div className="mt-3 pt-3 border-t border-white/5 space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Pass Rate</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaA.summary.passRate)}`}>
+                    {(metaA.summary.passRate * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Topic</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaA.summary.avgTopicScore)}`}>
+                    {metaA.summary.avgTopicScore.toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Safety</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaA.summary.avgSafetyScore)}`}>
+                    {metaA.summary.avgSafetyScore.toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Latency</span>
+                  <span className="text-xs font-semibold text-white">
+                    {metaA.summary.avgLatencyMs.toFixed(0)}ms
+                  </span>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Diff */}
+        <Card className="bg-white/[0.02]">
+          <CardContent>
+            <div className="text-xs text-white/40 mb-2">Difference (B - A)</div>
+            {metaA.summary && metaB.summary ? (
+              <div className="space-y-3 mt-3">
+                <DiffRow
+                  label="Pass Rate"
+                  a={metaA.summary.passRate}
+                  b={metaB.summary.passRate}
+                  format={(v) => `${(v * 100).toFixed(0)}%`}
+                  formatDiff={(d) => `${(d * 100).toFixed(1)}pp`}
+                />
+                <DiffRow
+                  label="Topic Score"
+                  a={metaA.summary.avgTopicScore}
+                  b={metaB.summary.avgTopicScore}
+                />
+                <DiffRow
+                  label="Safety Score"
+                  a={metaA.summary.avgSafetyScore}
+                  b={metaB.summary.avgSafetyScore}
+                />
+                <DiffRow
+                  label="Latency"
+                  a={metaA.summary.avgLatencyMs}
+                  b={metaB.summary.avgLatencyMs}
+                  format={(v) => `${v.toFixed(0)}ms`}
+                  formatDiff={(d) => `${d > 0 ? '+' : ''}${d.toFixed(0)}ms`}
+                  invertColor
+                />
+              </div>
+            ) : (
+              <p className="text-xs text-white/30 mt-4">
+                Summary data not available for both runs.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Run B */}
+        <Card>
+          <CardContent>
+            <div className="text-xs text-white/40 mb-2">Run B</div>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-sm font-semibold text-white">{truncateId(metaB.id)}</span>
+              {metaB.versionNumber !== null && metaB.versionNumber !== undefined && (
+                <Badge variant="default">v{metaB.versionNumber}</Badge>
+              )}
+            </div>
+            <div className="text-xs text-white/30">{formatRelativeTime(metaB.createdAt)}</div>
+            {metaB.summary && (
+              <div className="mt-3 pt-3 border-t border-white/5 space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Pass Rate</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaB.summary.passRate)}`}>
+                    {(metaB.summary.passRate * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Topic</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaB.summary.avgTopicScore)}`}>
+                    {metaB.summary.avgTopicScore.toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Safety</span>
+                  <span className={`text-xs font-semibold ${scoreColor(metaB.summary.avgSafetyScore)}`}>
+                    {metaB.summary.avgSafetyScore.toFixed(2)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-xs text-white/40">Latency</span>
+                  <span className="text-xs font-semibold text-white">
+                    {metaB.summary.avgLatencyMs.toFixed(0)}ms
+                  </span>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Per-case comparison */}
+      <div>
+        <h2 className="text-lg font-semibold text-white mb-3">Per-Case Comparison</h2>
+        {results.length === 0 ? (
+          <p className="text-sm text-white/40">No per-case results available.</p>
+        ) : (
+          <div className="space-y-2">
+            {results.map((item) => {
+              const isExpanded = expandedCase === item.caseId
+              return (
+                <Card key={item.caseId}>
+                  <CardContent className="!py-3">
+                    <button
+                      onClick={() => setExpandedCase(isExpanded ? null : item.caseId)}
+                      className="flex items-center justify-between w-full text-left"
+                    >
+                      <div className="flex items-center gap-2 min-w-0 flex-1">
+                        {isExpanded ? (
+                          <ChevronDown className="h-4 w-4 text-white/40 flex-shrink-0" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4 text-white/40 flex-shrink-0" />
+                        )}
+                        <span className="text-sm text-white truncate">{item.question}</span>
+                      </div>
+                      <div className="flex items-center gap-4 flex-shrink-0 ml-2">
+                        {/* Topic score comparison */}
+                        <div className="flex items-center gap-1">
+                          <span className={`text-xs ${scoreColor(item.resultA?.topicScore ?? null)}`}>
+                            {item.resultA?.topicScore?.toFixed(2) ?? '--'}
+                          </span>
+                          <DiffIndicator
+                            a={item.resultA?.topicScore ?? null}
+                            b={item.resultB?.topicScore ?? null}
+                          />
+                          <span className={`text-xs ${scoreColor(item.resultB?.topicScore ?? null)}`}>
+                            {item.resultB?.topicScore?.toFixed(2) ?? '--'}
+                          </span>
+                        </div>
+                        {/* Safety score comparison */}
+                        <div className="flex items-center gap-1">
+                          <span className={`text-xs ${scoreColor(item.resultA?.safetyScore ?? null)}`}>
+                            {item.resultA?.safetyScore?.toFixed(2) ?? '--'}
+                          </span>
+                          <DiffIndicator
+                            a={item.resultA?.safetyScore ?? null}
+                            b={item.resultB?.safetyScore ?? null}
+                          />
+                          <span className={`text-xs ${scoreColor(item.resultB?.safetyScore ?? null)}`}>
+                            {item.resultB?.safetyScore?.toFixed(2) ?? '--'}
+                          </span>
+                        </div>
+                      </div>
+                    </button>
+                    {isExpanded && (
+                      <div className="mt-3 pt-3 border-t border-white/5">
+                        <div className="grid grid-cols-2 gap-4">
+                          {/* Run A response */}
+                          <div>
+                            <div className="text-xs font-medium text-white/40 mb-1">
+                              Run A Response
+                            </div>
+                            {item.resultA?.agentResponse ? (
+                              <div className="text-xs text-white/60 bg-black/20 rounded-lg p-3 whitespace-pre-wrap max-h-40 overflow-y-auto">
+                                {item.resultA.agentResponse}
+                              </div>
+                            ) : (
+                              <p className="text-xs text-white/20 italic">No response</p>
+                            )}
+                            {item.resultA && (
+                              <div className="flex gap-3 mt-2">
+                                {item.resultA.topicScore !== null && (
+                                  <span className={`text-xs ${scoreColor(item.resultA.topicScore)}`}>
+                                    Topic: {item.resultA.topicScore.toFixed(2)}
+                                  </span>
+                                )}
+                                {item.resultA.safetyScore !== null && (
+                                  <span className={`text-xs ${scoreColor(item.resultA.safetyScore)}`}>
+                                    Safety: {item.resultA.safetyScore.toFixed(2)}
+                                  </span>
+                                )}
+                                {item.resultA.latencyMs !== null && (
+                                  <span className="text-xs text-white/30">
+                                    {item.resultA.latencyMs.toFixed(0)}ms
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {/* Run B response */}
+                          <div>
+                            <div className="text-xs font-medium text-white/40 mb-1">
+                              Run B Response
+                            </div>
+                            {item.resultB?.agentResponse ? (
+                              <div className="text-xs text-white/60 bg-black/20 rounded-lg p-3 whitespace-pre-wrap max-h-40 overflow-y-auto">
+                                {item.resultB.agentResponse}
+                              </div>
+                            ) : (
+                              <p className="text-xs text-white/20 italic">No response</p>
+                            )}
+                            {item.resultB && (
+                              <div className="flex gap-3 mt-2">
+                                {item.resultB.topicScore !== null && (
+                                  <span className={`text-xs ${scoreColor(item.resultB.topicScore)}`}>
+                                    Topic: {item.resultB.topicScore.toFixed(2)}
+                                  </span>
+                                )}
+                                {item.resultB.safetyScore !== null && (
+                                  <span className={`text-xs ${scoreColor(item.resultB.safetyScore)}`}>
+                                    Safety: {item.resultB.safetyScore.toFixed(2)}
+                                  </span>
+                                )}
+                                {item.resultB.latencyMs !== null && (
+                                  <span className="text-xs text-white/30">
+                                    {item.resultB.latencyMs.toFixed(0)}ms
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DiffRow({
+  label,
+  a,
+  b,
+  format = (v) => v.toFixed(2),
+  formatDiff,
+  invertColor = false,
+}: {
+  label: string
+  a: number
+  b: number
+  format?: (v: number) => string
+  formatDiff?: (d: number) => string
+  invertColor?: boolean
+}) {
+  const diff = b - a
+  const absDiff = Math.abs(diff)
+  const isPositive = diff > 0
+  const isNeutral = absDiff < 0.01
+
+  let colorClass = 'text-white/30'
+  if (!isNeutral) {
+    if (invertColor) {
+      colorClass = isPositive ? 'text-red-400' : 'text-green-400'
+    } else {
+      colorClass = isPositive ? 'text-green-400' : 'text-red-400'
+    }
+  }
+
+  const diffStr = formatDiff
+    ? formatDiff(diff)
+    : `${diff >= 0 ? '+' : ''}${diff.toFixed(2)}`
+
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-xs text-white/50">{label}</span>
+      <div className="flex items-center gap-2">
+        {!isNeutral && (
+          isPositive === !invertColor ? (
+            <ArrowUpRight className={`h-3 w-3 ${colorClass}`} />
+          ) : (
+            <ArrowDownRight className={`h-3 w-3 ${colorClass}`} />
+          )
+        )}
+        <span className={`text-xs font-semibold ${colorClass}`}>{diffStr}</span>
+      </div>
+    </div>
+  )
+}
+
+export default function EvalComparePage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <EvalCompareContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/eval-run/page.tsx
+++ b/packages/dashboard/app/agents/eval-run/page.tsx
@@ -1,0 +1,331 @@
+'use client'
+
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useEvalRunResults } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime, truncateId } from '@/lib/utils'
+import {
+  ArrowLeft,
+  BarChart3,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react'
+
+function statusVariant(status: string): 'success' | 'info' | 'error' | 'warning' | 'default' {
+  switch (status) {
+    case 'completed': return 'success'
+    case 'running': return 'info'
+    case 'error': return 'error'
+    case 'pending': return 'warning'
+    default: return 'default'
+  }
+}
+
+function scoreColor(score: number | null): string {
+  if (score === null) return 'text-white/30'
+  if (score >= 0.8) return 'text-green-400'
+  if (score >= 0.5) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+function EvalRunDetailContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const runId = searchParams.get('runId')
+  const { results, loading, refresh } = useEvalRunResults(name, runId)
+  const [run, setRun] = useState<any>(null)
+  const [runLoading, setRunLoading] = useState(true)
+  const [expandedResult, setExpandedResult] = useState<string | null>(null)
+
+  // Fetch the run metadata
+  useEffect(() => {
+    if (!name || !runId) {
+      setRunLoading(false)
+      return
+    }
+    async function fetchRun() {
+      try {
+        const data = await getClient().getEvalRun(name!, runId!)
+        setRun(data)
+      } catch (e) {
+        console.error('Failed to fetch eval run:', e)
+      } finally {
+        setRunLoading(false)
+      }
+    }
+    fetchRun()
+  }, [name, runId])
+
+  // Auto-refresh for in-progress runs
+  useEffect(() => {
+    if (!run) return
+    const isInProgress = run.status === 'running' || run.status === 'pending'
+    if (!isInProgress) return
+    const interval = setInterval(() => {
+      refresh()
+      // Re-fetch run metadata too
+      if (name && runId) {
+        getClient().getEvalRun(name, runId).then(setRun).catch(() => {})
+      }
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [run, refresh, name, runId])
+
+  if (!name || !runId) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">Missing agent name or run ID.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  if (runLoading || loading) {
+    return (
+      <div className="space-y-6">
+        <ShimmerBlock height={120} />
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={70} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/eval-runs?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to eval runs
+      </Link>
+
+      {/* Run Summary */}
+      <Card>
+        <CardContent>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl font-bold text-white">
+                  Run {truncateId(runId)}
+                </h1>
+                {run && (
+                  <Badge variant={statusVariant(run.status)}>
+                    {run.status === 'running' && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                    {run.status}
+                  </Badge>
+                )}
+                {run?.versionNumber !== null && run?.versionNumber !== undefined && (
+                  <Badge variant="default">v{run.versionNumber}</Badge>
+                )}
+              </div>
+              {run && (
+                <p className="text-xs text-white/30 mt-1">
+                  Started {formatRelativeTime(run.createdAt)}
+                  {run.completedAt && ` | Completed ${formatRelativeTime(run.completedAt)}`}
+                </p>
+              )}
+            </div>
+            {run && (
+              <div className="text-sm text-white/50">
+                {run.completedCases}/{run.totalCases} cases completed
+              </div>
+            )}
+          </div>
+
+          {/* Summary metrics */}
+          {run?.summary && (
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 mt-4 pt-4 border-t border-white/5">
+              <MetricCard
+                label="Pass Rate"
+                value={`${(run.summary.passRate * 100).toFixed(0)}%`}
+                color={run.summary.passRate >= 0.8 ? 'text-green-400' : run.summary.passRate >= 0.5 ? 'text-yellow-400' : 'text-red-400'}
+              />
+              <MetricCard
+                label="Avg Topic Score"
+                value={run.summary.avgTopicScore.toFixed(2)}
+                color={scoreColor(run.summary.avgTopicScore)}
+              />
+              <MetricCard
+                label="Avg Safety Score"
+                value={run.summary.avgSafetyScore.toFixed(2)}
+                color={scoreColor(run.summary.avgSafetyScore)}
+              />
+              {run.summary.avgLlmJudgeScore !== null && (
+                <MetricCard
+                  label="LLM Judge Score"
+                  value={run.summary.avgLlmJudgeScore.toFixed(2)}
+                  color={scoreColor(run.summary.avgLlmJudgeScore)}
+                />
+              )}
+              <MetricCard
+                label="Avg Latency"
+                value={`${run.summary.avgLatencyMs.toFixed(0)}ms`}
+                color="text-white"
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Results Table */}
+      <div>
+        <h2 className="text-lg font-semibold text-white mb-3">Results</h2>
+        {results.length === 0 ? (
+          <EmptyState
+            icon={<BarChart3 className="h-12 w-12" />}
+            title="No results yet"
+            description={run?.status === 'pending' || run?.status === 'running'
+              ? 'Results will appear as the eval run progresses.'
+              : 'No results were recorded for this run.'}
+          />
+        ) : (
+          <div className="space-y-2">
+            {results.map((result: any) => {
+              const isExpanded = expandedResult === result.id
+              return (
+                <Card key={result.id}>
+                  <CardContent className="!py-3">
+                    <div className="flex items-center justify-between">
+                      <button
+                        onClick={() => setExpandedResult(isExpanded ? null : result.id)}
+                        className="flex items-center gap-2 min-w-0 flex-1 text-left"
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="h-4 w-4 text-white/40 flex-shrink-0" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4 text-white/40 flex-shrink-0" />
+                        )}
+                        {result.status === 'completed' ? (
+                          <CheckCircle2 className="h-4 w-4 text-green-400 flex-shrink-0" />
+                        ) : result.status === 'error' ? (
+                          <XCircle className="h-4 w-4 text-red-400 flex-shrink-0" />
+                        ) : result.status === 'running' ? (
+                          <Loader2 className="h-4 w-4 text-blue-400 animate-spin flex-shrink-0" />
+                        ) : (
+                          <Clock className="h-4 w-4 text-yellow-400 flex-shrink-0" />
+                        )}
+                        <span className="text-sm text-white truncate">
+                          Case {truncateId(result.evalCaseId)}
+                        </span>
+                      </button>
+                      <div className="flex items-center gap-3 flex-shrink-0 ml-2">
+                        <Badge variant={statusVariant(result.status)}>{result.status}</Badge>
+                        {result.topicScore !== null && (
+                          <div className="text-right">
+                            <div className="text-[10px] text-white/30">Topic</div>
+                            <div className={`text-xs font-semibold ${scoreColor(result.topicScore)}`}>
+                              {result.topicScore.toFixed(2)}
+                            </div>
+                          </div>
+                        )}
+                        {result.safetyScore !== null && (
+                          <div className="text-right">
+                            <div className="text-[10px] text-white/30">Safety</div>
+                            <div className={`text-xs font-semibold ${scoreColor(result.safetyScore)}`}>
+                              {result.safetyScore.toFixed(2)}
+                            </div>
+                          </div>
+                        )}
+                        {result.latencyMs !== null && (
+                          <div className="text-right">
+                            <div className="text-[10px] text-white/30">Latency</div>
+                            <div className="text-xs font-semibold text-white">
+                              {result.latencyMs.toFixed(0)}ms
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    {isExpanded && (
+                      <div className="mt-3 pt-3 border-t border-white/5 space-y-3">
+                        {result.agentResponse && (
+                          <div>
+                            <div className="text-xs font-medium text-white/40 mb-1">Agent Response</div>
+                            <div className="text-sm text-white/70 bg-black/20 rounded-lg p-3 whitespace-pre-wrap max-h-48 overflow-y-auto">
+                              {result.agentResponse}
+                            </div>
+                          </div>
+                        )}
+                        {result.error && (
+                          <div>
+                            <div className="text-xs font-medium text-red-400 mb-1">Error</div>
+                            <div className="text-sm text-red-300 bg-red-500/10 rounded-lg p-3">
+                              {result.error}
+                            </div>
+                          </div>
+                        )}
+                        {result.llmJudgeScore !== null && (
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-white/40">LLM Judge Score:</span>
+                            <span className={`text-sm font-semibold ${scoreColor(result.llmJudgeScore)}`}>
+                              {result.llmJudgeScore.toFixed(2)}
+                            </span>
+                          </div>
+                        )}
+                        {result.humanScore !== null && (
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-white/40">Human Score:</span>
+                            <span className="text-sm font-semibold text-white">
+                              {result.humanScore}
+                            </span>
+                            {result.humanNotes && (
+                              <span className="text-xs text-white/50">- {result.humanNotes}</span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function MetricCard({
+  label,
+  value,
+  color,
+}: {
+  label: string
+  value: string
+  color: string
+}) {
+  return (
+    <div className="text-center">
+      <div className="text-xs text-white/40 mb-1">{label}</div>
+      <div className={`text-lg font-bold ${color}`}>{value}</div>
+    </div>
+  )
+}
+
+export default function EvalRunPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <EvalRunDetailContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/eval-runs/page.tsx
+++ b/packages/dashboard/app/agents/eval-runs/page.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useEvalRuns, useAgentVersions } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime, truncateId } from '@/lib/utils'
+import {
+  ArrowLeft,
+  Play,
+  BarChart3,
+  Loader2,
+  GitCompare,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  X,
+} from 'lucide-react'
+
+function statusIcon(status: string) {
+  switch (status) {
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4 text-green-400" />
+    case 'running':
+      return <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-red-400" />
+    case 'pending':
+      return <Clock className="h-4 w-4 text-yellow-400" />
+    default:
+      return <AlertTriangle className="h-4 w-4 text-white/40" />
+  }
+}
+
+function statusVariant(status: string): 'success' | 'info' | 'error' | 'warning' | 'default' {
+  switch (status) {
+    case 'completed': return 'success'
+    case 'running': return 'info'
+    case 'failed': return 'error'
+    case 'pending': return 'warning'
+    default: return 'default'
+  }
+}
+
+function EvalRunsContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const { runs, loading, refresh } = useEvalRuns(name)
+  const { versions } = useAgentVersions(name)
+  const [showRunModal, setShowRunModal] = useState(false)
+  const [compareMode, setCompareMode] = useState(false)
+  const [selectedRuns, setSelectedRuns] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  // Auto-refresh when there are running runs
+  useEffect(() => {
+    const hasRunning = runs.some((r: any) => r.status === 'running' || r.status === 'pending')
+    if (!hasRunning) return
+    const interval = setInterval(() => refresh(), 5000)
+    return () => clearInterval(interval)
+  }, [runs, refresh])
+
+  function toggleRunSelection(runId: string) {
+    setSelectedRuns((prev) => {
+      if (prev.includes(runId)) return prev.filter((id) => id !== runId)
+      if (prev.length >= 2) return [prev[1], runId]
+      return [...prev, runId]
+    })
+  }
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/evals?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to eval cases
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Eval Runs</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Run history for <span className="text-white/70">{name}</span>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {runs.length >= 2 && (
+            <Button
+              variant={compareMode ? 'primary' : 'secondary'}
+              onClick={() => {
+                setCompareMode(!compareMode)
+                setSelectedRuns([])
+              }}
+            >
+              <GitCompare className="h-4 w-4 mr-2" />
+              {compareMode ? 'Cancel Compare' : 'Compare'}
+            </Button>
+          )}
+          {compareMode && selectedRuns.length === 2 && (
+            <Link
+              href={`/agents/eval-compare?name=${encodeURIComponent(name)}&runA=${selectedRuns[0]}&runB=${selectedRuns[1]}`}
+            >
+              <Button>
+                <BarChart3 className="h-4 w-4 mr-2" />
+                Compare Selected
+              </Button>
+            </Link>
+          )}
+          {!compareMode && (
+            <Button onClick={() => setShowRunModal(true)}>
+              <Play className="h-4 w-4 mr-2" />
+              Run Evals
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {compareMode && (
+        <div className="text-sm text-white/50 bg-indigo-500/5 border border-indigo-500/20 rounded-lg px-4 py-2">
+          Select 2 runs to compare. Selected: {selectedRuns.length}/2
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={80} />
+          ))}
+        </div>
+      ) : runs.length === 0 ? (
+        <EmptyState
+          icon={<BarChart3 className="h-12 w-12" />}
+          title="No eval runs yet"
+          description="Start an eval run to test your agent against the defined eval cases."
+          action={
+            <Button onClick={() => setShowRunModal(true)}>
+              <Play className="h-4 w-4 mr-2" />
+              Run Evals
+            </Button>
+          }
+        />
+      ) : (
+        <div className="space-y-3">
+          {runs.map((run: any) => {
+            const isSelected = selectedRuns.includes(run.id)
+            return (
+              <Card
+                key={run.id}
+                className={compareMode && isSelected ? 'border-indigo-500/50 bg-indigo-500/5' : ''}
+              >
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3 min-w-0 flex-1">
+                      {compareMode && (
+                        <button
+                          onClick={() => toggleRunSelection(run.id)}
+                          className={`flex-shrink-0 h-5 w-5 rounded border-2 transition-colors ${
+                            isSelected
+                              ? 'bg-indigo-500 border-indigo-500'
+                              : 'border-white/20 hover:border-white/40'
+                          }`}
+                        >
+                          {isSelected && <CheckCircle2 className="h-4 w-4 text-white" />}
+                        </button>
+                      )}
+                      {statusIcon(run.status)}
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          {!compareMode ? (
+                            <Link
+                              href={`/agents/eval-run?name=${encodeURIComponent(name)}&runId=${run.id}`}
+                              className="text-sm font-semibold text-white hover:text-indigo-400 transition-colors"
+                            >
+                              Run {truncateId(run.id)}
+                            </Link>
+                          ) : (
+                            <span className="text-sm font-semibold text-white">
+                              Run {truncateId(run.id)}
+                            </span>
+                          )}
+                          <Badge variant={statusVariant(run.status)}>{run.status}</Badge>
+                          {run.versionNumber !== null && run.versionNumber !== undefined && (
+                            <Badge variant="default">v{run.versionNumber}</Badge>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3 mt-1">
+                          <span className="text-xs text-white/30">
+                            {formatRelativeTime(run.createdAt)}
+                          </span>
+                          <span className="text-xs text-white/30">
+                            {run.completedCases}/{run.totalCases} cases
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    {run.summary && (
+                      <div className="flex items-center gap-4 flex-shrink-0">
+                        <div className="text-right">
+                          <div className="text-xs text-white/40">Pass Rate</div>
+                          <div className={`text-sm font-semibold ${
+                            run.summary.passRate >= 0.8
+                              ? 'text-green-400'
+                              : run.summary.passRate >= 0.5
+                                ? 'text-yellow-400'
+                                : 'text-red-400'
+                          }`}>
+                            {(run.summary.passRate * 100).toFixed(0)}%
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className="text-xs text-white/40">Topic</div>
+                          <div className="text-sm font-semibold text-white">
+                            {run.summary.avgTopicScore.toFixed(2)}
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className="text-xs text-white/40">Safety</div>
+                          <div className="text-sm font-semibold text-white">
+                            {run.summary.avgSafetyScore.toFixed(2)}
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className="text-xs text-white/40">Latency</div>
+                          <div className="text-sm font-semibold text-white">
+                            {run.summary.avgLatencyMs.toFixed(0)}ms
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Run Evals Modal */}
+      {showRunModal && (
+        <RunEvalsModal
+          agentName={name}
+          versions={versions}
+          onClose={() => setShowRunModal(false)}
+          onStarted={() => {
+            setShowRunModal(false)
+            refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── Run Evals Modal ───
+
+function RunEvalsModal({
+  agentName,
+  versions,
+  onClose,
+  onStarted,
+}: {
+  agentName: string
+  versions: any[]
+  onClose: () => void
+  onStarted: () => void
+}) {
+  const [versionNumber, setVersionNumber] = useState<string>('')
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleStart() {
+    setStarting(true)
+    setError(null)
+    try {
+      await getClient().startEvalRun(agentName, {
+        versionNumber: versionNumber ? Number(versionNumber) : undefined,
+      })
+      onStarted()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to start eval run')
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  const versionOptions = versions.map((v: any) => ({
+    value: String(v.versionNumber),
+    label: `v${v.versionNumber}${v.name ? ` - ${v.name}` : ''}${v.isActive ? ' (active)' : ''}`,
+  }))
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-md">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">Run Evals</h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <Select
+              label="Version (optional)"
+              placeholder="Use active version"
+              options={versionOptions}
+              value={versionNumber}
+              onChange={(e) => setVersionNumber(e.target.value)}
+            />
+
+            <p className="text-xs text-white/40">
+              This will run all active eval cases against the selected version of the agent.
+            </p>
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleStart} disabled={starting}>
+                {starting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Starting...
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-4 w-4 mr-2" />
+                    Start Run
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default function EvalRunsPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <EvalRunsContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/evals/page.tsx
+++ b/packages/dashboard/app/agents/evals/page.tsx
@@ -1,0 +1,448 @@
+'use client'
+
+import { Suspense, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useEvalCases } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import {
+  ArrowLeft,
+  FlaskConical,
+  Plus,
+  Trash2,
+  Pencil,
+  Download,
+  Upload,
+  Play,
+  X,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react'
+
+function EvalsContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const { cases, loading, refresh } = useEvalCases(name)
+  const [showCreate, setShowCreate] = useState(false)
+  const [editCase, setEditCase] = useState<any | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
+  const [expandedCase, setExpandedCase] = useState<string | null>(null)
+  const [importing, setImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete(caseId: string) {
+    if (!name) return
+    setError(null)
+    try {
+      await getClient().deleteEvalCase(name, caseId)
+      setDeleteConfirm(null)
+      refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete eval case')
+      setDeleteConfirm(null)
+    }
+  }
+
+  async function handleExport() {
+    if (!name) return
+    setError(null)
+    try {
+      const data = await getClient().exportEvalCases(name)
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${name}-eval-cases.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to export eval cases')
+    }
+  }
+
+  async function handleImport(fileList: FileList) {
+    if (!name || fileList.length === 0) return
+    setImporting(true)
+    setError(null)
+    try {
+      const text = await fileList[0].text()
+      const parsed = JSON.parse(text)
+      const casesToImport = Array.isArray(parsed) ? parsed : parsed.cases || []
+      await getClient().importEvalCases(name, casesToImport)
+      refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to import eval cases')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/detail?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to {name}
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Eval Cases</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Test cases for <span className="text-white/70">{name}</span>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link href={`/agents/eval-runs?name=${encodeURIComponent(name)}`}>
+            <Button variant="secondary">
+              <Play className="h-4 w-4 mr-2" />
+              Eval Runs
+            </Button>
+          </Link>
+          <Button variant="secondary" onClick={handleExport}>
+            <Download className="h-4 w-4 mr-2" />
+            Export
+          </Button>
+          <label className="cursor-pointer">
+            <span className="inline-flex items-center justify-center font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 disabled:pointer-events-none disabled:opacity-50 border border-white/20 bg-white/5 text-white hover:bg-white/10 hover:border-white/30 h-9 px-4 text-sm rounded-xl">
+              <Upload className="h-4 w-4 mr-2" />
+              {importing ? 'Importing...' : 'Import'}
+            </span>
+            <input
+              type="file"
+              accept=".json"
+              className="hidden"
+              onChange={(e) => {
+                if (e.target.files) {
+                  handleImport(e.target.files)
+                  e.target.value = ''
+                }
+              }}
+            />
+          </label>
+          <Button onClick={() => setShowCreate(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Case
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={70} />
+          ))}
+        </div>
+      ) : cases.length === 0 ? (
+        <EmptyState
+          icon={<FlaskConical className="h-12 w-12" />}
+          title="No eval cases yet"
+          description="Create test cases to evaluate your agent's responses. Define questions, expected topics, and reference answers."
+          action={
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Eval Case
+            </Button>
+          }
+        />
+      ) : (
+        <div className="space-y-2">
+          {cases.map((evalCase: any) => {
+            const isExpanded = expandedCase === evalCase.id
+            return (
+              <Card key={evalCase.id}>
+                <CardContent className="!py-3">
+                  <div className="flex items-center justify-between">
+                    <button
+                      onClick={() => setExpandedCase(isExpanded ? null : evalCase.id)}
+                      className="flex items-center gap-2 min-w-0 flex-1 text-left"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown className="h-4 w-4 text-white/40 flex-shrink-0" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-white/40 flex-shrink-0" />
+                      )}
+                      <span className="text-sm text-white truncate">{evalCase.question}</span>
+                    </button>
+                    <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                      {evalCase.category && (
+                        <Badge variant="info">{evalCase.category}</Badge>
+                      )}
+                      {!evalCase.isActive && (
+                        <Badge variant="warning">Inactive</Badge>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditCase(evalCase)}
+                        className="text-white/30 hover:text-white"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteConfirm(evalCase.id)}
+                        className="text-white/30 hover:text-red-400"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                  {isExpanded && (
+                    <div className="mt-3 pt-3 border-t border-white/5 space-y-2">
+                      {evalCase.expectedTopics && evalCase.expectedTopics.length > 0 && (
+                        <div>
+                          <span className="text-xs font-medium text-white/40">Expected topics: </span>
+                          <span className="text-xs text-white/60">
+                            {evalCase.expectedTopics.join(', ')}
+                          </span>
+                        </div>
+                      )}
+                      {evalCase.expectedNotTopics && evalCase.expectedNotTopics.length > 0 && (
+                        <div>
+                          <span className="text-xs font-medium text-white/40">Should NOT mention: </span>
+                          <span className="text-xs text-white/60">
+                            {evalCase.expectedNotTopics.join(', ')}
+                          </span>
+                        </div>
+                      )}
+                      {evalCase.referenceAnswer && (
+                        <div>
+                          <span className="text-xs font-medium text-white/40">Reference answer: </span>
+                          <p className="text-xs text-white/60 mt-0.5">{evalCase.referenceAnswer}</p>
+                        </div>
+                      )}
+                      {evalCase.tags && evalCase.tags.length > 0 && (
+                        <div className="flex items-center gap-1 mt-1">
+                          {evalCase.tags.map((tag: string) => (
+                            <Badge key={tag} variant="default">{tag}</Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Create / Edit Modal */}
+      {(showCreate || editCase) && (
+        <EvalCaseModal
+          agentName={name}
+          evalCase={editCase}
+          onClose={() => {
+            setShowCreate(false)
+            setEditCase(null)
+          }}
+          onSaved={() => {
+            setShowCreate(false)
+            setEditCase(null)
+            refresh()
+          }}
+        />
+      )}
+
+      {/* Delete Confirmation */}
+      {deleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <Card className="w-full max-w-md">
+            <CardContent>
+              <h3 className="text-lg font-semibold text-white mb-2">Delete Eval Case</h3>
+              <p className="text-sm text-white/60 mb-6">
+                Are you sure you want to delete this eval case? This action cannot be undone.
+              </p>
+              <div className="flex justify-end gap-3">
+                <Button variant="ghost" onClick={() => setDeleteConfirm(null)}>
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={() => handleDelete(deleteConfirm)}>
+                  Delete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Eval Case Create/Edit Modal ───
+
+function EvalCaseModal({
+  agentName,
+  evalCase,
+  onClose,
+  onSaved,
+}: {
+  agentName: string
+  evalCase: any | null
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const isEdit = !!evalCase
+  const [question, setQuestion] = useState(evalCase?.question || '')
+  const [expectedTopics, setExpectedTopics] = useState(
+    evalCase?.expectedTopics?.join(', ') || ''
+  )
+  const [expectedNotTopics, setExpectedNotTopics] = useState(
+    evalCase?.expectedNotTopics?.join(', ') || ''
+  )
+  const [referenceAnswer, setReferenceAnswer] = useState(evalCase?.referenceAnswer || '')
+  const [category, setCategory] = useState(evalCase?.category || '')
+  const [tags, setTags] = useState(evalCase?.tags?.join(', ') || '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function parseList(s: string): string[] {
+    return s
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+  }
+
+  async function handleSave() {
+    if (!question.trim()) {
+      setError('Question is required')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const data = {
+        question: question.trim(),
+        expectedTopics: expectedTopics ? parseList(expectedTopics) : undefined,
+        expectedNotTopics: expectedNotTopics ? parseList(expectedNotTopics) : undefined,
+        referenceAnswer: referenceAnswer || undefined,
+        category: category || undefined,
+        tags: tags ? parseList(tags) : undefined,
+      }
+      if (isEdit) {
+        await getClient().updateEvalCase(agentName, evalCase.id, data)
+      } else {
+        await getClient().createEvalCase(agentName, data)
+      }
+      onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save eval case')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-auto">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">
+              {isEdit ? 'Edit Eval Case' : 'Add Eval Case'}
+            </h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-white/70">Question</label>
+              <textarea
+                value={question}
+                onChange={(e) => setQuestion(e.target.value)}
+                rows={3}
+                placeholder="What question should the agent answer?"
+                className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+              />
+            </div>
+            <Input
+              label="Expected Topics (comma-separated)"
+              placeholder="e.g. pricing, features, support"
+              value={expectedTopics}
+              onChange={(e) => setExpectedTopics(e.target.value)}
+            />
+            <Input
+              label="Should NOT Mention (comma-separated)"
+              placeholder="e.g. competitor names, internal details"
+              value={expectedNotTopics}
+              onChange={(e) => setExpectedNotTopics(e.target.value)}
+            />
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-white/70">
+                Reference Answer (optional)
+              </label>
+              <textarea
+                value={referenceAnswer}
+                onChange={(e) => setReferenceAnswer(e.target.value)}
+                rows={3}
+                placeholder="The ideal answer for comparison..."
+                className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+              />
+            </div>
+            <Input
+              label="Category"
+              placeholder="e.g. accuracy, safety, edge_case"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <Input
+              label="Tags (comma-separated)"
+              placeholder="e.g. regression, critical"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving...' : isEdit ? 'Update' : 'Create'}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default function EvalsPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <EvalsContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/knowledge/page.tsx
+++ b/packages/dashboard/app/agents/knowledge/page.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { Suspense, useState, useRef, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useAgentFiles } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import {
+  ArrowLeft,
+  BookOpen,
+  Upload,
+  Trash2,
+  FileText,
+  ChevronDown,
+  ChevronRight,
+  X,
+  Loader2,
+} from 'lucide-react'
+
+function KnowledgeContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const { files, loading, refresh } = useAgentFiles(name)
+  const [expandedFile, setExpandedFile] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleUpload = useCallback(async (fileList: FileList) => {
+    if (!name) return
+    setUploading(true)
+    setError(null)
+    try {
+      const filesToUpload: Array<{ path: string; content: string }> = []
+      for (const file of Array.from(fileList)) {
+        const text = await file.text()
+        filesToUpload.push({ path: file.name, content: text })
+      }
+      await getClient().uploadAgentFiles(name, filesToUpload)
+      refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to upload files')
+    } finally {
+      setUploading(false)
+    }
+  }, [name, refresh])
+
+  async function handleDelete(filePath: string) {
+    if (!name) return
+    setDeleting(filePath)
+    setError(null)
+    try {
+      await getClient().deleteAgentFile(name, filePath)
+      setExpandedFile(null)
+      refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete file')
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/detail?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to {name}
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Knowledge Base</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Files for <span className="text-white/70">{name}</span>
+          </p>
+        </div>
+        <Button onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+          {uploading ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Upload className="h-4 w-4 mr-2" />
+          )}
+          {uploading ? 'Uploading...' : 'Upload Files'}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files && e.target.files.length > 0) {
+              handleUpload(e.target.files)
+              e.target.value = ''
+            }
+          }}
+        />
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={60} />
+          ))}
+        </div>
+      ) : files.length === 0 ? (
+        <EmptyState
+          icon={<BookOpen className="h-12 w-12" />}
+          title="No files yet"
+          description="Upload knowledge base files for your agent. These files will be available in the agent's working directory."
+          action={
+            <Button onClick={() => fileInputRef.current?.click()}>
+              <Upload className="h-4 w-4 mr-2" />
+              Upload Files
+            </Button>
+          }
+        />
+      ) : (
+        <div className="space-y-2">
+          {files.map((file: any) => {
+            const filePath = typeof file === 'string' ? file : file.path || file.name
+            const isExpanded = expandedFile === filePath
+            return (
+              <Card key={filePath}>
+                <CardContent className="!py-3">
+                  <div className="flex items-center justify-between">
+                    <button
+                      onClick={() => setExpandedFile(isExpanded ? null : filePath)}
+                      className="flex items-center gap-2 min-w-0 flex-1 text-left"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown className="h-4 w-4 text-white/40 flex-shrink-0" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-white/40 flex-shrink-0" />
+                      )}
+                      <FileText className="h-4 w-4 text-indigo-400 flex-shrink-0" />
+                      <span className="text-sm text-white truncate">{filePath}</span>
+                    </button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(filePath)}
+                      disabled={deleting === filePath}
+                      className="text-white/30 hover:text-red-400 flex-shrink-0 ml-2"
+                    >
+                      {deleting === filePath ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                  {isExpanded && typeof file === 'object' && file.content && (
+                    <div className="mt-3 pt-3 border-t border-white/5">
+                      <pre className="text-xs text-white/60 bg-black/20 rounded-lg p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap">
+                        {file.content}
+                      </pre>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function KnowledgePage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <KnowledgeContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/page.tsx
+++ b/packages/dashboard/app/agents/page.tsx
@@ -147,9 +147,11 @@ function AgentCard({
       <CardContent>
         <div className="flex items-start justify-between">
           <div className="min-w-0 flex-1">
-            <h3 className="text-sm font-semibold text-white truncate">
-              {agent.name}
-            </h3>
+            <Link href={`/agents/detail?name=${encodeURIComponent(agent.name)}`}>
+              <h3 className="text-sm font-semibold text-white truncate hover:text-indigo-400 transition-colors cursor-pointer">
+                {agent.name}
+              </h3>
+            </Link>
             {agent.description && (
               <p className="text-xs text-white/40 mt-1 line-clamp-2">
                 {agent.description}

--- a/packages/dashboard/app/agents/versions/page.tsx
+++ b/packages/dashboard/app/agents/versions/page.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { Suspense, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useAgentVersions } from '@/lib/hooks'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import { formatRelativeTime } from '@/lib/utils'
+import {
+  ArrowLeft,
+  GitBranch,
+  Plus,
+  CheckCircle2,
+  Loader2,
+  X,
+} from 'lucide-react'
+
+function VersionsContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const { versions, loading, refresh } = useAgentVersions(name)
+  const [showCreate, setShowCreate] = useState(false)
+  const [activating, setActivating] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleActivate(versionNumber: number) {
+    if (!name) return
+    setActivating(versionNumber)
+    setError(null)
+    try {
+      await getClient().activateAgentVersion(name, versionNumber)
+      refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to activate version')
+    } finally {
+      setActivating(null)
+    }
+  }
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/detail?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to {name}
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Versions</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Manage versions for <span className="text-white/70">{name}</span>
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Version
+        </Button>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <ShimmerBlock key={i} height={80} />
+          ))}
+        </div>
+      ) : versions.length === 0 ? (
+        <EmptyState
+          icon={<GitBranch className="h-12 w-12" />}
+          title="No versions yet"
+          description="Create your first version to snapshot the agent's configuration."
+          action={
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Create Version
+            </Button>
+          }
+        />
+      ) : (
+        <div className="space-y-3">
+          {versions.map((version) => (
+            <Card key={version.id}>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-sm font-semibold text-white">
+                        v{version.versionNumber}
+                      </h3>
+                      {version.name && (
+                        <span className="text-sm text-white/50">{version.name}</span>
+                      )}
+                      {version.isActive && (
+                        <Badge variant="success">
+                          <CheckCircle2 className="h-3 w-3 mr-1" />
+                          Active
+                        </Badge>
+                      )}
+                    </div>
+                    {version.releaseNotes && (
+                      <p className="text-xs text-white/40 mt-1">{version.releaseNotes}</p>
+                    )}
+                    <div className="flex items-center gap-3 mt-2">
+                      <span className="text-xs text-white/30">
+                        {formatRelativeTime(version.createdAt)}
+                      </span>
+                      {version.systemPrompt && (
+                        <span className="text-xs text-white/30">Has system prompt</span>
+                      )}
+                      {version.knowledgeFiles && version.knowledgeFiles.length > 0 && (
+                        <span className="text-xs text-white/30">
+                          {version.knowledgeFiles.length} knowledge file{version.knowledgeFiles.length !== 1 ? 's' : ''}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {!version.isActive && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleActivate(version.versionNumber)}
+                      disabled={activating === version.versionNumber}
+                    >
+                      {activating === version.versionNumber ? (
+                        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                      ) : (
+                        <CheckCircle2 className="h-3 w-3 mr-1" />
+                      )}
+                      Activate
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Create Version Modal */}
+      {showCreate && (
+        <CreateVersionModal
+          agentName={name}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false)
+            refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── Create Version Modal ───
+
+function CreateVersionModal({
+  agentName,
+  onClose,
+  onCreated,
+}: {
+  agentName: string
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [versionName, setVersionName] = useState('')
+  const [systemPrompt, setSystemPrompt] = useState('')
+  const [releaseNotes, setReleaseNotes] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleCreate() {
+    setCreating(true)
+    setError(null)
+    try {
+      await getClient().createAgentVersion(agentName, {
+        name: versionName || undefined,
+        systemPrompt: systemPrompt || undefined,
+        releaseNotes: releaseNotes || undefined,
+      })
+      onCreated()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create version')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-auto">
+        <CardContent>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-lg font-semibold text-white">Create Version</h2>
+            <button onClick={onClose} className="text-white/40 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <Input
+              label="Version Name (optional)"
+              placeholder="e.g. v2 - improved grounding"
+              value={versionName}
+              onChange={(e) => setVersionName(e.target.value)}
+            />
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-white/70">
+                System Prompt (optional)
+              </label>
+              <textarea
+                value={systemPrompt}
+                onChange={(e) => setSystemPrompt(e.target.value)}
+                rows={4}
+                placeholder="System prompt for this version..."
+                className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-white/70">
+                Release Notes (optional)
+              </label>
+              <textarea
+                value={releaseNotes}
+                onChange={(e) => setReleaseNotes(e.target.value)}
+                rows={2}
+                placeholder="What changed in this version..."
+                className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+              />
+            </div>
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleCreate} disabled={creating}>
+                {creating ? 'Creating...' : 'Create Version'}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default function VersionsPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <VersionsContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/lib/hooks.ts
+++ b/packages/dashboard/lib/hooks.ts
@@ -185,3 +185,123 @@ export function useUsageStats(opts?: {
 
   return { stats, loading, error, refetch }
 }
+
+// ─── useAgentVersions ───
+
+export function useAgentVersions(agentName: string | null) {
+  const [versions, setVersions] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!agentName) return
+    try {
+      setLoading(true)
+      const data = await getClient().listAgentVersions(agentName)
+      setVersions(data)
+    } catch (err) {
+      console.error('Failed to fetch versions:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [agentName])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { versions, loading, refresh }
+}
+
+// ─── useAgentFiles ───
+
+export function useAgentFiles(agentName: string | null) {
+  const [files, setFiles] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!agentName) return
+    try {
+      setLoading(true)
+      const data = await getClient().listAgentFiles(agentName)
+      setFiles(data.files)
+    } catch (err) {
+      console.error('Failed to fetch files:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [agentName])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { files, loading, refresh }
+}
+
+// ─── useEvalCases ───
+
+export function useEvalCases(agentName: string | null) {
+  const [cases, setCases] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!agentName) return
+    try {
+      setLoading(true)
+      const data = await getClient().listEvalCases(agentName)
+      setCases(data)
+    } catch (err) {
+      console.error('Failed to fetch eval cases:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [agentName])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { cases, loading, refresh }
+}
+
+// ─── useEvalRuns ───
+
+export function useEvalRuns(agentName: string | null) {
+  const [runs, setRuns] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!agentName) return
+    try {
+      setLoading(true)
+      const data = await getClient().listEvalRuns(agentName)
+      setRuns(data)
+    } catch (err) {
+      console.error('Failed to fetch eval runs:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [agentName])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { runs, loading, refresh }
+}
+
+// ─── useEvalRunResults ───
+
+export function useEvalRunResults(agentName: string | null, runId: string | null) {
+  const [results, setResults] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!agentName || !runId) return
+    try {
+      setLoading(true)
+      const data = await getClient().getEvalRunResults(agentName, runId)
+      setResults(data)
+    } catch (err) {
+      console.error('Failed to fetch eval results:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [agentName, runId])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { results, loading, refresh }
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,10 @@
 import type {
   Agent,
   AgentUpdate,
+  AgentVersion,
+  CreateAgentVersionRequest,
+  UpdateAgentVersionRequest,
+  ListAgentVersionsResponse,
   Session,
   SessionStatus,
   Message,
@@ -37,6 +41,15 @@ import type {
   WriteSessionFilesResponse,
   DeleteSessionFileResponse,
   McpServerConfig,
+  EvalCase,
+  CreateEvalCaseRequest,
+  EvalRun,
+  CreateEvalRunRequest,
+  EvalResult,
+  ListEvalCasesResponse,
+  ListEvalRunsResponse,
+  ListEvalResultsResponse,
+  EvalRunComparison,
 } from '@ash-ai/shared';
 import { parseSSEStream } from './sse.js';
 
@@ -601,5 +614,102 @@ export class AshClient {
 
   async health(): Promise<HealthResponse> {
     return this.request<HealthResponse>('GET', '/health');
+  }
+
+  // -- Agent Versions -----------------------------------------------------------
+
+  async listAgentVersions(agentName: string): Promise<AgentVersion[]> {
+    const res = await this.request<ListAgentVersionsResponse>('GET', `/api/agents/${encodeURIComponent(agentName)}/versions`);
+    return res.versions;
+  }
+
+  async createAgentVersion(agentName: string, opts: CreateAgentVersionRequest = {}): Promise<AgentVersion> {
+    return this.request<AgentVersion>('POST', `/api/agents/${encodeURIComponent(agentName)}/versions`, opts);
+  }
+
+  async getAgentVersion(agentName: string, versionNumber: number): Promise<AgentVersion> {
+    return this.request<AgentVersion>('GET', `/api/agents/${encodeURIComponent(agentName)}/versions/${versionNumber}`);
+  }
+
+  async updateAgentVersion(agentName: string, versionNumber: number, updates: UpdateAgentVersionRequest): Promise<AgentVersion> {
+    return this.request<AgentVersion>('PATCH', `/api/agents/${encodeURIComponent(agentName)}/versions/${versionNumber}`, updates);
+  }
+
+  async deleteAgentVersion(agentName: string, versionNumber: number): Promise<void> {
+    await this.request('DELETE', `/api/agents/${encodeURIComponent(agentName)}/versions/${versionNumber}`);
+  }
+
+  async activateAgentVersion(agentName: string, versionNumber: number): Promise<void> {
+    await this.request('POST', `/api/agents/${encodeURIComponent(agentName)}/versions/${versionNumber}/activate`);
+  }
+
+  // -- Agent Files (Knowledge Base) ---------------------------------------------
+
+  async uploadAgentFiles(agentName: string, files: Array<{ path: string; content: string }>): Promise<{ written: number }> {
+    return this.request<{ written: number }>('POST', `/api/agents/${encodeURIComponent(agentName)}/files`, { files });
+  }
+
+  async deleteAgentFile(agentName: string, filePath: string): Promise<{ deleted: boolean }> {
+    return this.request<{ deleted: boolean }>('DELETE', `/api/agents/${encodeURIComponent(agentName)}/files/${filePath}`);
+  }
+
+  // -- Eval Cases ---------------------------------------------------------------
+
+  async listEvalCases(agentName: string, opts?: { category?: string; isActive?: boolean }): Promise<EvalCase[]> {
+    const params = new URLSearchParams();
+    if (opts?.category) params.set('category', opts.category);
+    if (opts?.isActive !== undefined) params.set('isActive', String(opts.isActive));
+    const qs = params.toString();
+    const res = await this.request<ListEvalCasesResponse>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-cases${qs ? '?' + qs : ''}`);
+    return res.cases;
+  }
+
+  async createEvalCase(agentName: string, data: CreateEvalCaseRequest): Promise<EvalCase> {
+    return this.request<EvalCase>('POST', `/api/agents/${encodeURIComponent(agentName)}/eval-cases`, data);
+  }
+
+  async getEvalCase(agentName: string, caseId: string): Promise<EvalCase> {
+    return this.request<EvalCase>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-cases/${caseId}`);
+  }
+
+  async updateEvalCase(agentName: string, caseId: string, data: Partial<CreateEvalCaseRequest>): Promise<EvalCase> {
+    return this.request<EvalCase>('PATCH', `/api/agents/${encodeURIComponent(agentName)}/eval-cases/${caseId}`, data);
+  }
+
+  async deleteEvalCase(agentName: string, caseId: string): Promise<void> {
+    await this.request('DELETE', `/api/agents/${encodeURIComponent(agentName)}/eval-cases/${caseId}`);
+  }
+
+  async importEvalCases(agentName: string, cases: CreateEvalCaseRequest[]): Promise<{ imported: number }> {
+    return this.request<{ imported: number }>('POST', `/api/agents/${encodeURIComponent(agentName)}/eval-cases/import`, { cases });
+  }
+
+  async exportEvalCases(agentName: string): Promise<EvalCase[]> {
+    const res = await this.request<ListEvalCasesResponse>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-cases/export`);
+    return res.cases;
+  }
+
+  // -- Eval Runs ----------------------------------------------------------------
+
+  async startEvalRun(agentName: string, opts?: CreateEvalRunRequest): Promise<EvalRun> {
+    return this.request<EvalRun>('POST', `/api/agents/${encodeURIComponent(agentName)}/eval-runs`, opts || {});
+  }
+
+  async listEvalRuns(agentName: string): Promise<EvalRun[]> {
+    const res = await this.request<ListEvalRunsResponse>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-runs`);
+    return res.runs;
+  }
+
+  async getEvalRun(agentName: string, runId: string): Promise<EvalRun> {
+    return this.request<EvalRun>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-runs/${runId}`);
+  }
+
+  async getEvalRunResults(agentName: string, runId: string): Promise<EvalResult[]> {
+    const res = await this.request<ListEvalResultsResponse>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-runs/${runId}/results`);
+    return res.results;
+  }
+
+  async compareEvalRuns(agentName: string, runAId: string, runBId: string): Promise<EvalRunComparison> {
+    return this.request<EvalRunComparison>('GET', `/api/agents/${encodeURIComponent(agentName)}/eval-runs/compare?runA=${runAId}&runB=${runBId}`);
   }
 }

--- a/packages/server/drizzle/pg/0011_typical_swarm.sql
+++ b/packages/server/drizzle/pg/0011_typical_swarm.sql
@@ -1,0 +1,73 @@
+CREATE TABLE "agent_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"agent_name" text NOT NULL,
+	"version_number" integer NOT NULL,
+	"name" text DEFAULT '' NOT NULL,
+	"system_prompt" text,
+	"release_notes" text,
+	"is_active" integer DEFAULT 0 NOT NULL,
+	"knowledge_files" text,
+	"created_by" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "eval_cases" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"agent_name" text NOT NULL,
+	"question" text NOT NULL,
+	"expected_topics" text,
+	"expected_not_topics" text,
+	"reference_answer" text,
+	"category" text,
+	"tags" text,
+	"chat_history" text,
+	"is_active" integer DEFAULT 1 NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "eval_results" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"eval_run_id" text NOT NULL,
+	"eval_case_id" text NOT NULL,
+	"agent_response" text,
+	"topic_score" real,
+	"safety_score" real,
+	"llm_judge_score" real,
+	"latency_ms" integer,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"error" text,
+	"human_score" real,
+	"human_notes" text,
+	"created_at" text NOT NULL,
+	"completed_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "eval_runs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"agent_name" text NOT NULL,
+	"version_number" integer,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"total_cases" integer DEFAULT 0 NOT NULL,
+	"completed_cases" integer DEFAULT 0 NOT NULL,
+	"summary" text,
+	"filters" text,
+	"created_at" text NOT NULL,
+	"started_at" text,
+	"completed_at" text
+);
+--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "active_version_id" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_agent_versions_unique" ON "agent_versions" USING btree ("tenant_id","agent_name","version_number");--> statement-breakpoint
+CREATE INDEX "idx_agent_versions_active" ON "agent_versions" USING btree ("tenant_id","agent_name","is_active");--> statement-breakpoint
+CREATE INDEX "idx_eval_cases_agent" ON "eval_cases" USING btree ("tenant_id","agent_name");--> statement-breakpoint
+CREATE INDEX "idx_eval_cases_category" ON "eval_cases" USING btree ("category");--> statement-breakpoint
+CREATE INDEX "idx_eval_results_run" ON "eval_results" USING btree ("eval_run_id");--> statement-breakpoint
+CREATE INDEX "idx_eval_results_case" ON "eval_results" USING btree ("eval_case_id");--> statement-breakpoint
+CREATE INDEX "idx_eval_runs_agent" ON "eval_runs" USING btree ("tenant_id","agent_name");--> statement-breakpoint
+CREATE INDEX "idx_eval_runs_status" ON "eval_runs" USING btree ("status");

--- a/packages/server/drizzle/pg/meta/0011_snapshot.json
+++ b/packages/server/drizzle/pg/meta/0011_snapshot.json
@@ -1,0 +1,1764 @@
+{
+  "id": "45a53df4-4c22-4da1-9dcd-7cfb16cf4759",
+  "prevId": "1de53387-76c0-47d5-8f72-48f95a14bb3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_versions": {
+      "name": "agent_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "knowledge_files": {
+          "name": "knowledge_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_agent_versions_unique": {
+          "name": "idx_agent_versions_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_versions_active": {
+          "name": "idx_agent_versions_active",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_agents_tenant_name": {
+          "name": "idx_agents_tenant_name",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_tenant": {
+          "name": "idx_agents_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_tenant": {
+          "name": "idx_api_keys_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_attachments_session": {
+          "name": "idx_attachments_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachments_message": {
+          "name": "idx_attachments_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_tenant": {
+          "name": "idx_credentials_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eval_cases": {
+      "name": "eval_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_topics": {
+          "name": "expected_topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_not_topics": {
+          "name": "expected_not_topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_answer": {
+          "name": "reference_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_history": {
+          "name": "chat_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_cases_agent": {
+          "name": "idx_eval_cases_agent",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_cases_category": {
+          "name": "idx_eval_cases_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eval_results": {
+      "name": "eval_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "eval_run_id": {
+          "name": "eval_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eval_case_id": {
+          "name": "eval_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_response": {
+          "name": "agent_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_score": {
+          "name": "topic_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_score": {
+          "name": "safety_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_judge_score": {
+          "name": "llm_judge_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "human_notes": {
+          "name": "human_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_eval_results_run": {
+          "name": "idx_eval_results_run",
+          "columns": [
+            {
+              "expression": "eval_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_case": {
+          "name": "idx_eval_results_case",
+          "columns": [
+            {
+              "expression": "eval_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eval_runs": {
+      "name": "eval_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_cases": {
+          "name": "completed_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_eval_runs_agent": {
+          "name": "idx_eval_runs_agent",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_runs_status": {
+          "name": "idx_eval_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_unique_seq": {
+          "name": "idx_messages_unique_seq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_session": {
+          "name": "idx_messages_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.queue_items": {
+      "name": "queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_queue_tenant": {
+          "name": "idx_queue_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_queue_status": {
+          "name": "idx_queue_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners": {
+      "name": "runners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_sandboxes": {
+          "name": "max_sandboxes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "active_count": {
+          "name": "active_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "warming_count": {
+          "name": "warming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_runners_heartbeat": {
+          "name": "idx_runners_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandboxes": {
+      "name": "sandboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warming'"
+        },
+        "workspace_dir": {
+          "name": "workspace_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_state": {
+          "name": "idx_sandboxes_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_session": {
+          "name": "idx_sandboxes_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_last_used": {
+          "name": "idx_sandboxes_last_used",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_tenant": {
+          "name": "idx_sandboxes_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_session_events_unique_seq": {
+          "name": "idx_session_events_unique_seq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_session": {
+          "name": "idx_session_events_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_type": {
+          "name": "idx_session_events_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_tenant": {
+          "name": "idx_sessions_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_runner": {
+          "name": "idx_sessions_runner",
+          "columns": [
+            {
+              "expression": "runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_session": {
+          "name": "idx_usage_session",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_type": {
+          "name": "idx_usage_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/pg/meta/_journal.json
+++ b/packages/server/drizzle/pg/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772851318205,
       "tag": "0010_steep_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773445135653,
+      "tag": "0011_typical_swarm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0011_yielding_morlun.sql
+++ b/packages/server/drizzle/sqlite/0011_yielding_morlun.sql
@@ -1,0 +1,73 @@
+CREATE TABLE `agent_versions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text DEFAULT 'default' NOT NULL,
+	`agent_name` text NOT NULL,
+	`version_number` integer NOT NULL,
+	`name` text DEFAULT '' NOT NULL,
+	`system_prompt` text,
+	`release_notes` text,
+	`is_active` integer DEFAULT 0 NOT NULL,
+	`knowledge_files` text,
+	`created_by` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_agent_versions_unique` ON `agent_versions` (`tenant_id`,`agent_name`,`version_number`);--> statement-breakpoint
+CREATE INDEX `idx_agent_versions_active` ON `agent_versions` (`tenant_id`,`agent_name`,`is_active`);--> statement-breakpoint
+CREATE TABLE `eval_cases` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text DEFAULT 'default' NOT NULL,
+	`agent_name` text NOT NULL,
+	`question` text NOT NULL,
+	`expected_topics` text,
+	`expected_not_topics` text,
+	`reference_answer` text,
+	`category` text,
+	`tags` text,
+	`chat_history` text,
+	`is_active` integer DEFAULT 1 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_eval_cases_agent` ON `eval_cases` (`tenant_id`,`agent_name`);--> statement-breakpoint
+CREATE INDEX `idx_eval_cases_category` ON `eval_cases` (`category`);--> statement-breakpoint
+CREATE TABLE `eval_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text DEFAULT 'default' NOT NULL,
+	`eval_run_id` text NOT NULL,
+	`eval_case_id` text NOT NULL,
+	`agent_response` text,
+	`topic_score` real,
+	`safety_score` real,
+	`llm_judge_score` real,
+	`latency_ms` integer,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`error` text,
+	`human_score` real,
+	`human_notes` text,
+	`created_at` text NOT NULL,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_eval_results_run` ON `eval_results` (`eval_run_id`);--> statement-breakpoint
+CREATE INDEX `idx_eval_results_case` ON `eval_results` (`eval_case_id`);--> statement-breakpoint
+CREATE TABLE `eval_runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text DEFAULT 'default' NOT NULL,
+	`agent_name` text NOT NULL,
+	`version_number` integer,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`total_cases` integer DEFAULT 0 NOT NULL,
+	`completed_cases` integer DEFAULT 0 NOT NULL,
+	`summary` text,
+	`filters` text,
+	`created_at` text NOT NULL,
+	`started_at` text,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_eval_runs_agent` ON `eval_runs` (`tenant_id`,`agent_name`);--> statement-breakpoint
+CREATE INDEX `idx_eval_runs_status` ON `eval_runs` (`status`);--> statement-breakpoint
+ALTER TABLE `agents` ADD `active_version_id` text;

--- a/packages/server/drizzle/sqlite/meta/0011_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0011_snapshot.json
@@ -1,0 +1,1504 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e8859b37-ea4f-4321-8683-3b0f2b37cd36",
+  "prevId": "23aa4123-21f1-48f7-b509-a40cbde8fea8",
+  "tables": {
+    "agent_versions": {
+      "name": "agent_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "knowledge_files": {
+          "name": "knowledge_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_versions_unique": {
+          "name": "idx_agent_versions_unique",
+          "columns": [
+            "tenant_id",
+            "agent_name",
+            "version_number"
+          ],
+          "isUnique": true
+        },
+        "idx_agent_versions_active": {
+          "name": "idx_agent_versions_active",
+          "columns": [
+            "tenant_id",
+            "agent_name",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_tenant_name": {
+          "name": "idx_agents_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_agents_tenant": {
+          "name": "idx_agents_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_api_keys_tenant": {
+          "name": "idx_api_keys_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attachments_session": {
+          "name": "idx_attachments_session",
+          "columns": [
+            "tenant_id",
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attachments_message": {
+          "name": "idx_attachments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credentials": {
+      "name": "credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_tenant": {
+          "name": "idx_credentials_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_cases": {
+      "name": "eval_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_topics": {
+          "name": "expected_topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_not_topics": {
+          "name": "expected_not_topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_answer": {
+          "name": "reference_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_history": {
+          "name": "chat_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_eval_cases_agent": {
+          "name": "idx_eval_cases_agent",
+          "columns": [
+            "tenant_id",
+            "agent_name"
+          ],
+          "isUnique": false
+        },
+        "idx_eval_cases_category": {
+          "name": "idx_eval_cases_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "eval_run_id": {
+          "name": "eval_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eval_case_id": {
+          "name": "eval_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_response": {
+          "name": "agent_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_score": {
+          "name": "topic_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_score": {
+          "name": "safety_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_judge_score": {
+          "name": "llm_judge_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_notes": {
+          "name": "human_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_eval_results_run": {
+          "name": "idx_eval_results_run",
+          "columns": [
+            "eval_run_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eval_results_case": {
+          "name": "idx_eval_results_case",
+          "columns": [
+            "eval_case_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_runs": {
+      "name": "eval_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_cases": {
+          "name": "completed_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_eval_runs_agent": {
+          "name": "idx_eval_runs_agent",
+          "columns": [
+            "tenant_id",
+            "agent_name"
+          ],
+          "isUnique": false
+        },
+        "idx_eval_runs_status": {
+          "name": "idx_eval_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_unique_seq": {
+          "name": "idx_messages_unique_seq",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session": {
+          "name": "idx_messages_session",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queue_items": {
+      "name": "queue_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_queue_tenant": {
+          "name": "idx_queue_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_queue_status": {
+          "name": "idx_queue_status",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runners": {
+      "name": "runners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_sandboxes": {
+          "name": "max_sandboxes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "active_count": {
+          "name": "active_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "warming_count": {
+          "name": "warming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_runners_heartbeat": {
+          "name": "idx_runners_heartbeat",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sandboxes": {
+      "name": "sandboxes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'warming'"
+        },
+        "workspace_dir": {
+          "name": "workspace_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_state": {
+          "name": "idx_sandboxes_state",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_session": {
+          "name": "idx_sandboxes_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_last_used": {
+          "name": "idx_sandboxes_last_used",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sandboxes_tenant": {
+          "name": "idx_sandboxes_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_events": {
+      "name": "session_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_events_unique_seq": {
+          "name": "idx_session_events_unique_seq",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "idx_session_events_session": {
+          "name": "idx_session_events_session",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "idx_session_events_type": {
+          "name": "idx_session_events_type",
+          "columns": [
+            "tenant_id",
+            "session_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_tenant": {
+          "name": "idx_sessions_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_runner": {
+          "name": "idx_sessions_runner",
+          "columns": [
+            "runner_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_events": {
+      "name": "usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_usage_session": {
+          "name": "idx_usage_session",
+          "columns": [
+            "tenant_id",
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            "tenant_id",
+            "agent_name"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_type": {
+          "name": "idx_usage_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772851317613,
       "tag": "0010_wooden_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1773445126854,
+      "tag": "0011_yielding_morlun",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/openapi.test.ts
+++ b/packages/server/src/__tests__/openapi.test.ts
@@ -82,7 +82,7 @@ describe('OpenAPI spec generation', () => {
         if (path[method]) count++;
       }
     }
-    expect(count).toBe(26);
+    expect(count).toBe(28);
   });
 
   it('has component schemas for Agent, Session, ApiError, HealthResponse', () => {

--- a/packages/server/src/db/drizzle-db.ts
+++ b/packages/server/src/db/drizzle-db.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { eq, and, sql, gt, lt, ne, asc, desc, inArray } from 'drizzle-orm';
-import type { Agent, Session, SessionStatus, SessionConfig, SandboxRecord, SandboxState, ApiKey, Message, SessionEvent, SessionEventType, RunnerRecord, Credential, QueueItem, QueueItemStatus, QueueStats, Attachment, UsageEvent, UsageEventType, UsageStats } from '@ash-ai/shared';
+import { eq, and, sql, gt, lt, gte, ne, asc, desc, inArray } from 'drizzle-orm';
+import type { Agent, Session, SessionStatus, SessionConfig, SandboxRecord, SandboxState, ApiKey, Message, SessionEvent, SessionEventType, RunnerRecord, Credential, QueueItem, QueueItemStatus, QueueStats, Attachment, UsageEvent, UsageEventType, UsageStats, AgentVersion, EvalCase, EvalRun, EvalRunStatus, EvalResult, EvalResultStatus, EvalRunSummary } from '@ash-ai/shared';
 import type { Db } from './index.js';
 
 import type * as sqliteSchema from './schema.sqlite.js';
@@ -19,6 +19,92 @@ function parseConfig(raw: string | null | undefined): SessionConfig | null {
 function parseEnv(raw: string | null | undefined): Record<string, string> | undefined {
   if (!raw) return undefined;
   try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+/** Parse JSON array column. Returns null on null/invalid. */
+function parseJsonArray<T = unknown>(raw: string | null | undefined): T[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch { return null; }
+}
+
+/** Parse JSON object column. Returns null on null/invalid. */
+function parseJsonObject<T = unknown>(raw: string | null | undefined): T | null {
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+function mapAgentVersion(r: any): AgentVersion {
+  return {
+    id: r.id,
+    tenantId: r.tenantId,
+    agentName: r.agentName,
+    versionNumber: r.versionNumber,
+    name: r.name,
+    systemPrompt: r.systemPrompt ?? null,
+    releaseNotes: r.releaseNotes ?? null,
+    isActive: r.isActive === 1,
+    knowledgeFiles: parseJsonArray<string>(r.knowledgeFiles),
+    createdBy: r.createdBy ?? null,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+function mapEvalCase(r: any): EvalCase {
+  return {
+    id: r.id,
+    tenantId: r.tenantId,
+    agentName: r.agentName,
+    question: r.question,
+    expectedTopics: parseJsonArray<string>(r.expectedTopics),
+    expectedNotTopics: parseJsonArray<string>(r.expectedNotTopics),
+    referenceAnswer: r.referenceAnswer ?? null,
+    category: r.category ?? null,
+    tags: parseJsonArray<string>(r.tags),
+    chatHistory: parseJsonArray<{ role: string; content: string }>(r.chatHistory),
+    isActive: r.isActive === 1,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+function mapEvalRun(r: any): EvalRun {
+  return {
+    id: r.id,
+    tenantId: r.tenantId,
+    agentName: r.agentName,
+    versionNumber: r.versionNumber ?? null,
+    status: r.status as EvalRunStatus,
+    totalCases: r.totalCases,
+    completedCases: r.completedCases,
+    summary: parseJsonObject<EvalRunSummary>(r.summary),
+    createdAt: r.createdAt,
+    startedAt: r.startedAt ?? null,
+    completedAt: r.completedAt ?? null,
+  };
+}
+
+function mapEvalResult(r: any): EvalResult {
+  return {
+    id: r.id,
+    tenantId: r.tenantId,
+    evalRunId: r.evalRunId,
+    evalCaseId: r.evalCaseId,
+    agentResponse: r.agentResponse ?? null,
+    topicScore: r.topicScore ?? null,
+    safetyScore: r.safetyScore ?? null,
+    llmJudgeScore: r.llmJudgeScore ?? null,
+    latencyMs: r.latencyMs ?? null,
+    status: r.status as EvalResultStatus,
+    error: r.error ?? null,
+    humanScore: r.humanScore ?? null,
+    humanNotes: r.humanNotes ?? null,
+    createdAt: r.createdAt,
+    completedAt: r.completedAt ?? null,
+  };
 }
 
 /**
@@ -957,6 +1043,383 @@ export class DrizzleDb implements Db {
       if (key) stats[key] = Number(r.total);
     }
     return stats;
+  }
+
+  // -- Agent Versions ---------------------------------------------------------
+
+  async insertAgentVersion(id: string, tenantId: string, agentName: string, versionNumber: number, opts: {
+    name?: string;
+    systemPrompt?: string | null;
+    releaseNotes?: string | null;
+    knowledgeFiles?: string[] | null;
+    createdBy?: string | null;
+  }): Promise<AgentVersion> {
+    const { agentVersions } = this.schema;
+    const now = new Date().toISOString();
+    const row = {
+      id,
+      tenantId,
+      agentName,
+      versionNumber,
+      name: opts.name ?? '',
+      systemPrompt: opts.systemPrompt ?? null,
+      releaseNotes: opts.releaseNotes ?? null,
+      isActive: 0,
+      knowledgeFiles: opts.knowledgeFiles ? JSON.stringify(opts.knowledgeFiles) : null,
+      createdBy: opts.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.drizzle.insert(agentVersions).values(row);
+    return mapAgentVersion(row);
+  }
+
+  async getAgentVersion(id: string): Promise<AgentVersion | null> {
+    const { agentVersions } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(agentVersions)
+      .where(eq(agentVersions.id, id))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapAgentVersion(rows[0]);
+  }
+
+  async getAgentVersionByNumber(agentName: string, versionNumber: number, tenantId: string = 'default'): Promise<AgentVersion | null> {
+    const { agentVersions } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(agentVersions)
+      .where(and(
+        eq(agentVersions.tenantId, tenantId),
+        eq(agentVersions.agentName, agentName),
+        eq(agentVersions.versionNumber, versionNumber),
+      ))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapAgentVersion(rows[0]);
+  }
+
+  async getActiveAgentVersion(agentName: string, tenantId: string = 'default'): Promise<AgentVersion | null> {
+    const { agentVersions } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(agentVersions)
+      .where(and(
+        eq(agentVersions.tenantId, tenantId),
+        eq(agentVersions.agentName, agentName),
+        eq(agentVersions.isActive, 1),
+      ))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapAgentVersion(rows[0]);
+  }
+
+  async listAgentVersions(agentName: string, tenantId: string = 'default'): Promise<AgentVersion[]> {
+    const { agentVersions } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(agentVersions)
+      .where(and(
+        eq(agentVersions.tenantId, tenantId),
+        eq(agentVersions.agentName, agentName),
+      ))
+      .orderBy(desc(agentVersions.versionNumber));
+    return rows.map(mapAgentVersion);
+  }
+
+  async activateAgentVersion(id: string, agentName: string, tenantId: string = 'default'): Promise<void> {
+    const { agentVersions, agents } = this.schema;
+    await this.drizzle.transaction(async (tx: any) => {
+      // Deactivate all versions for this agent
+      await tx.update(agentVersions)
+        .set({ isActive: 0, updatedAt: new Date().toISOString() })
+        .where(and(eq(agentVersions.tenantId, tenantId), eq(agentVersions.agentName, agentName)));
+      // Activate the target version
+      await tx.update(agentVersions)
+        .set({ isActive: 1, updatedAt: new Date().toISOString() })
+        .where(eq(agentVersions.id, id));
+      // Update agents table
+      await tx.update(agents)
+        .set({ activeVersionId: id, updatedAt: new Date().toISOString() })
+        .where(and(eq(agents.tenantId, tenantId), eq(agents.name, agentName)));
+    });
+  }
+
+  async getNextVersionNumber(agentName: string, tenantId: string = 'default'): Promise<number> {
+    const { agentVersions } = this.schema;
+    const rows = await this.drizzle
+      .select({ maxVersion: sql<number>`COALESCE(MAX(${agentVersions.versionNumber}), 0)` })
+      .from(agentVersions)
+      .where(and(eq(agentVersions.tenantId, tenantId), eq(agentVersions.agentName, agentName)));
+    return (rows[0]?.maxVersion ?? 0) + 1;
+  }
+
+  async updateAgentVersion(id: string, updates: { name?: string; systemPrompt?: string | null; releaseNotes?: string | null; knowledgeFiles?: string[] | null }): Promise<AgentVersion | null> {
+    const { agentVersions } = this.schema;
+    const now = new Date().toISOString();
+    const set: Record<string, unknown> = { updatedAt: now };
+    if (updates.name !== undefined) set.name = updates.name;
+    if (updates.systemPrompt !== undefined) set.systemPrompt = updates.systemPrompt;
+    if (updates.releaseNotes !== undefined) set.releaseNotes = updates.releaseNotes;
+    if (updates.knowledgeFiles !== undefined) set.knowledgeFiles = updates.knowledgeFiles ? JSON.stringify(updates.knowledgeFiles) : null;
+
+    await this.drizzle
+      .update(agentVersions)
+      .set(set)
+      .where(eq(agentVersions.id, id));
+
+    return this.getAgentVersion(id);
+  }
+
+  async deleteAgentVersion(id: string): Promise<boolean> {
+    const { agentVersions } = this.schema;
+    const result = await this.drizzle
+      .delete(agentVersions)
+      .where(eq(agentVersions.id, id));
+    return (result.changes ?? result.rowCount ?? 0) > 0;
+  }
+
+  // -- Eval Cases -------------------------------------------------------------
+
+  async insertEvalCase(id: string, tenantId: string, agentName: string, data: {
+    question: string;
+    expectedTopics?: string[] | null;
+    expectedNotTopics?: string[] | null;
+    referenceAnswer?: string | null;
+    category?: string | null;
+    tags?: string[] | null;
+    chatHistory?: Array<{ role: string; content: string }> | null;
+    isActive?: boolean;
+  }): Promise<EvalCase> {
+    const { evalCases } = this.schema;
+    const now = new Date().toISOString();
+    const row = {
+      id,
+      tenantId,
+      agentName,
+      question: data.question,
+      expectedTopics: data.expectedTopics ? JSON.stringify(data.expectedTopics) : null,
+      expectedNotTopics: data.expectedNotTopics ? JSON.stringify(data.expectedNotTopics) : null,
+      referenceAnswer: data.referenceAnswer ?? null,
+      category: data.category ?? null,
+      tags: data.tags ? JSON.stringify(data.tags) : null,
+      chatHistory: data.chatHistory ? JSON.stringify(data.chatHistory) : null,
+      isActive: data.isActive === false ? 0 : 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.drizzle.insert(evalCases).values(row);
+    return mapEvalCase(row);
+  }
+
+  async getEvalCase(id: string): Promise<EvalCase | null> {
+    const { evalCases } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalCases)
+      .where(eq(evalCases.id, id))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapEvalCase(rows[0]);
+  }
+
+  async listEvalCases(tenantId: string, agentName: string, opts?: { category?: string; isActive?: boolean }): Promise<EvalCase[]> {
+    const { evalCases } = this.schema;
+    const conditions: any[] = [
+      eq(evalCases.tenantId, tenantId),
+      eq(evalCases.agentName, agentName),
+    ];
+    if (opts?.category) {
+      conditions.push(eq(evalCases.category, opts.category));
+    }
+    if (opts?.isActive !== undefined) {
+      conditions.push(eq(evalCases.isActive, opts.isActive ? 1 : 0));
+    }
+    const rows = await this.drizzle
+      .select()
+      .from(evalCases)
+      .where(and(...conditions))
+      .orderBy(asc(evalCases.createdAt));
+    return rows.map(mapEvalCase);
+  }
+
+  async updateEvalCase(id: string, data: Partial<{
+    question: string;
+    expectedTopics: string[] | null;
+    expectedNotTopics: string[] | null;
+    referenceAnswer: string | null;
+    category: string | null;
+    tags: string[] | null;
+    chatHistory: Array<{ role: string; content: string }> | null;
+    isActive: boolean;
+  }>): Promise<EvalCase | null> {
+    const { evalCases } = this.schema;
+    const now = new Date().toISOString();
+    const set: Record<string, unknown> = { updatedAt: now };
+    if (data.question !== undefined) set.question = data.question;
+    if (data.expectedTopics !== undefined) set.expectedTopics = data.expectedTopics ? JSON.stringify(data.expectedTopics) : null;
+    if (data.expectedNotTopics !== undefined) set.expectedNotTopics = data.expectedNotTopics ? JSON.stringify(data.expectedNotTopics) : null;
+    if (data.referenceAnswer !== undefined) set.referenceAnswer = data.referenceAnswer;
+    if (data.category !== undefined) set.category = data.category;
+    if (data.tags !== undefined) set.tags = data.tags ? JSON.stringify(data.tags) : null;
+    if (data.chatHistory !== undefined) set.chatHistory = data.chatHistory ? JSON.stringify(data.chatHistory) : null;
+    if (data.isActive !== undefined) set.isActive = data.isActive ? 1 : 0;
+
+    await this.drizzle
+      .update(evalCases)
+      .set(set)
+      .where(eq(evalCases.id, id));
+
+    return this.getEvalCase(id);
+  }
+
+  async deleteEvalCase(id: string): Promise<boolean> {
+    const { evalCases } = this.schema;
+    const result = await this.drizzle
+      .delete(evalCases)
+      .where(eq(evalCases.id, id));
+    return (result.changes ?? result.rowCount ?? 0) > 0;
+  }
+
+  // -- Eval Runs --------------------------------------------------------------
+
+  async insertEvalRun(id: string, tenantId: string, agentName: string, opts?: { versionNumber?: number; filters?: Record<string, unknown> }): Promise<EvalRun> {
+    const { evalRuns } = this.schema;
+    const now = new Date().toISOString();
+    const row = {
+      id,
+      tenantId,
+      agentName,
+      versionNumber: opts?.versionNumber ?? null,
+      status: 'pending',
+      totalCases: 0,
+      completedCases: 0,
+      summary: null,
+      filters: opts?.filters ? JSON.stringify(opts.filters) : null,
+      createdAt: now,
+      startedAt: null,
+      completedAt: null,
+    };
+    await this.drizzle.insert(evalRuns).values(row);
+    return mapEvalRun(row);
+  }
+
+  async getEvalRun(id: string): Promise<EvalRun | null> {
+    const { evalRuns } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalRuns)
+      .where(eq(evalRuns.id, id))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapEvalRun(rows[0]);
+  }
+
+  async listEvalRuns(tenantId: string, agentName: string): Promise<EvalRun[]> {
+    const { evalRuns } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalRuns)
+      .where(and(
+        eq(evalRuns.tenantId, tenantId),
+        eq(evalRuns.agentName, agentName),
+      ))
+      .orderBy(desc(evalRuns.createdAt));
+    return rows.map(mapEvalRun);
+  }
+
+  async listPendingEvalRuns(): Promise<EvalRun[]> {
+    const { evalRuns } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalRuns)
+      .where(eq(evalRuns.status, 'pending'))
+      .orderBy(evalRuns.createdAt);
+    return rows.map(mapEvalRun);
+  }
+
+  async updateEvalRun(id: string, updates: Partial<{ status: EvalRunStatus; totalCases: number; completedCases: number; summary: EvalRunSummary | null; startedAt: string; completedAt: string }>): Promise<void> {
+    const { evalRuns } = this.schema;
+    const set: Record<string, unknown> = {};
+    if (updates.status !== undefined) set.status = updates.status;
+    if (updates.totalCases !== undefined) set.totalCases = updates.totalCases;
+    if (updates.completedCases !== undefined) set.completedCases = updates.completedCases;
+    if (updates.summary !== undefined) set.summary = updates.summary ? JSON.stringify(updates.summary) : null;
+    if (updates.startedAt !== undefined) set.startedAt = updates.startedAt;
+    if (updates.completedAt !== undefined) set.completedAt = updates.completedAt;
+
+    await this.drizzle
+      .update(evalRuns)
+      .set(set)
+      .where(eq(evalRuns.id, id));
+  }
+
+  // -- Eval Results -----------------------------------------------------------
+
+  async insertEvalResult(id: string, tenantId: string, evalRunId: string, evalCaseId: string): Promise<EvalResult> {
+    const { evalResults } = this.schema;
+    const now = new Date().toISOString();
+    const row = {
+      id,
+      tenantId,
+      evalRunId,
+      evalCaseId,
+      agentResponse: null,
+      topicScore: null,
+      safetyScore: null,
+      llmJudgeScore: null,
+      latencyMs: null,
+      status: 'pending',
+      error: null,
+      humanScore: null,
+      humanNotes: null,
+      createdAt: now,
+      completedAt: null,
+    };
+    await this.drizzle.insert(evalResults).values(row);
+    return mapEvalResult(row);
+  }
+
+  async getEvalResult(id: string): Promise<EvalResult | null> {
+    const { evalResults } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalResults)
+      .where(eq(evalResults.id, id))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return mapEvalResult(rows[0]);
+  }
+
+  async listEvalResults(evalRunId: string): Promise<EvalResult[]> {
+    const { evalResults } = this.schema;
+    const rows = await this.drizzle
+      .select()
+      .from(evalResults)
+      .where(eq(evalResults.evalRunId, evalRunId))
+      .orderBy(asc(evalResults.createdAt));
+    return rows.map(mapEvalResult);
+  }
+
+  async updateEvalResult(id: string, updates: Partial<{ agentResponse: string; topicScore: number; safetyScore: number; llmJudgeScore: number; latencyMs: number; status: EvalResultStatus; error: string; humanScore: number; humanNotes: string; completedAt: string }>): Promise<void> {
+    const { evalResults } = this.schema;
+    const set: Record<string, unknown> = {};
+    if (updates.agentResponse !== undefined) set.agentResponse = updates.agentResponse;
+    if (updates.topicScore !== undefined) set.topicScore = updates.topicScore;
+    if (updates.safetyScore !== undefined) set.safetyScore = updates.safetyScore;
+    if (updates.llmJudgeScore !== undefined) set.llmJudgeScore = updates.llmJudgeScore;
+    if (updates.latencyMs !== undefined) set.latencyMs = updates.latencyMs;
+    if (updates.status !== undefined) set.status = updates.status;
+    if (updates.error !== undefined) set.error = updates.error;
+    if (updates.humanScore !== undefined) set.humanScore = updates.humanScore;
+    if (updates.humanNotes !== undefined) set.humanNotes = updates.humanNotes;
+    if (updates.completedAt !== undefined) set.completedAt = updates.completedAt;
+
+    await this.drizzle
+      .update(evalResults)
+      .set(set)
+      .where(eq(evalResults.id, id));
   }
 
   // -- Lifecycle --------------------------------------------------------------

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,7 +1,7 @@
 import { join, resolve, dirname } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import type { Agent, Session, SessionStatus, SessionConfig, SandboxRecord, SandboxState, ApiKey, Message, SessionEvent, SessionEventType, RunnerRecord, Credential, QueueItem, QueueItemStatus, QueueStats, Attachment, UsageEvent, UsageEventType, UsageStats } from '@ash-ai/shared';
+import type { Agent, Session, SessionStatus, SessionConfig, SandboxRecord, SandboxState, ApiKey, Message, SessionEvent, SessionEventType, RunnerRecord, Credential, QueueItem, QueueItemStatus, QueueStats, Attachment, UsageEvent, UsageEventType, UsageStats, AgentVersion, EvalCase, EvalRun, EvalRunStatus, EvalResult, EvalResultStatus, EvalRunSummary } from '@ash-ai/shared';
 
 /** Resolve the package root from the current file — works from both src/ (tsx) and dist/ (compiled). */
 function pkgRoot(): string {
@@ -98,6 +98,57 @@ export interface Db {
   insertUsageEvents(events: Array<{ id: string; tenantId: string; sessionId: string; agentName: string; eventType: UsageEventType; value: number }>): Promise<void>;
   listUsageEvents(tenantId: string, opts?: { sessionId?: string; agentName?: string; after?: string; before?: string; limit?: number }): Promise<UsageEvent[]>;
   getUsageStats(tenantId: string, opts?: { sessionId?: string; agentName?: string; after?: string; before?: string }): Promise<UsageStats>;
+  // Agent Versions (tenant-scoped)
+  insertAgentVersion(id: string, tenantId: string, agentName: string, versionNumber: number, opts: {
+    name?: string;
+    systemPrompt?: string | null;
+    releaseNotes?: string | null;
+    knowledgeFiles?: string[] | null;
+    createdBy?: string | null;
+  }): Promise<AgentVersion>;
+  getAgentVersion(id: string): Promise<AgentVersion | null>;
+  getAgentVersionByNumber(agentName: string, versionNumber: number, tenantId?: string): Promise<AgentVersion | null>;
+  getActiveAgentVersion(agentName: string, tenantId?: string): Promise<AgentVersion | null>;
+  listAgentVersions(agentName: string, tenantId?: string): Promise<AgentVersion[]>;
+  activateAgentVersion(id: string, agentName: string, tenantId?: string): Promise<void>;
+  getNextVersionNumber(agentName: string, tenantId?: string): Promise<number>;
+  updateAgentVersion(id: string, updates: { name?: string; systemPrompt?: string | null; releaseNotes?: string | null; knowledgeFiles?: string[] | null }): Promise<AgentVersion | null>;
+  deleteAgentVersion(id: string): Promise<boolean>;
+  // Eval Cases (tenant-scoped)
+  insertEvalCase(id: string, tenantId: string, agentName: string, data: {
+    question: string;
+    expectedTopics?: string[] | null;
+    expectedNotTopics?: string[] | null;
+    referenceAnswer?: string | null;
+    category?: string | null;
+    tags?: string[] | null;
+    chatHistory?: Array<{ role: string; content: string }> | null;
+    isActive?: boolean;
+  }): Promise<EvalCase>;
+  getEvalCase(id: string): Promise<EvalCase | null>;
+  listEvalCases(tenantId: string, agentName: string, opts?: { category?: string; isActive?: boolean }): Promise<EvalCase[]>;
+  updateEvalCase(id: string, data: Partial<{
+    question: string;
+    expectedTopics: string[] | null;
+    expectedNotTopics: string[] | null;
+    referenceAnswer: string | null;
+    category: string | null;
+    tags: string[] | null;
+    chatHistory: Array<{ role: string; content: string }> | null;
+    isActive: boolean;
+  }>): Promise<EvalCase | null>;
+  deleteEvalCase(id: string): Promise<boolean>;
+  // Eval Runs (tenant-scoped)
+  insertEvalRun(id: string, tenantId: string, agentName: string, opts?: { versionNumber?: number; filters?: Record<string, unknown> }): Promise<EvalRun>;
+  getEvalRun(id: string): Promise<EvalRun | null>;
+  listEvalRuns(tenantId: string, agentName: string): Promise<EvalRun[]>;
+  listPendingEvalRuns(): Promise<EvalRun[]>;
+  updateEvalRun(id: string, updates: Partial<{ status: EvalRunStatus; totalCases: number; completedCases: number; summary: EvalRunSummary | null; startedAt: string; completedAt: string }>): Promise<void>;
+  // Eval Results (tenant-scoped)
+  insertEvalResult(id: string, tenantId: string, evalRunId: string, evalCaseId: string): Promise<EvalResult>;
+  getEvalResult(id: string): Promise<EvalResult | null>;
+  listEvalResults(evalRunId: string): Promise<EvalResult[]>;
+  updateEvalResult(id: string, updates: Partial<{ agentResponse: string; topicScore: number; safetyScore: number; llmJudgeScore: number; latencyMs: number; status: EvalResultStatus; error: string; humanScore: number; humanNotes: string; completedAt: string }>): Promise<void>;
   // Lifecycle
   close(): Promise<void>;
 }
@@ -447,6 +498,130 @@ export async function listUsageEvents(tenantId: string, opts?: { sessionId?: str
 
 export async function getUsageStats(tenantId: string, opts?: { sessionId?: string; agentName?: string; after?: string; before?: string }): Promise<UsageStats> {
   return getDb().getUsageStats(tenantId, opts);
+}
+
+// -- Agent Versions -----------------------------------------------------------
+
+export async function insertAgentVersion(id: string, tenantId: string, agentName: string, versionNumber: number, opts: {
+  name?: string;
+  systemPrompt?: string | null;
+  releaseNotes?: string | null;
+  knowledgeFiles?: string[] | null;
+  createdBy?: string | null;
+}): Promise<AgentVersion> {
+  return getDb().insertAgentVersion(id, tenantId, agentName, versionNumber, opts);
+}
+
+export async function getAgentVersion(id: string): Promise<AgentVersion | null> {
+  return getDb().getAgentVersion(id);
+}
+
+export async function getAgentVersionByNumber(agentName: string, versionNumber: number, tenantId?: string): Promise<AgentVersion | null> {
+  return getDb().getAgentVersionByNumber(agentName, versionNumber, tenantId);
+}
+
+export async function getActiveAgentVersion(agentName: string, tenantId?: string): Promise<AgentVersion | null> {
+  return getDb().getActiveAgentVersion(agentName, tenantId);
+}
+
+export async function listAgentVersions(agentName: string, tenantId?: string): Promise<AgentVersion[]> {
+  return getDb().listAgentVersions(agentName, tenantId);
+}
+
+export async function activateAgentVersion(id: string, agentName: string, tenantId?: string): Promise<void> {
+  return getDb().activateAgentVersion(id, agentName, tenantId);
+}
+
+export async function getNextVersionNumber(agentName: string, tenantId?: string): Promise<number> {
+  return getDb().getNextVersionNumber(agentName, tenantId);
+}
+
+export async function updateAgentVersion(id: string, updates: { name?: string; systemPrompt?: string | null; releaseNotes?: string | null; knowledgeFiles?: string[] | null }): Promise<AgentVersion | null> {
+  return getDb().updateAgentVersion(id, updates);
+}
+
+export async function deleteAgentVersion(id: string): Promise<boolean> {
+  return getDb().deleteAgentVersion(id);
+}
+
+// -- Eval Cases ---------------------------------------------------------------
+
+export async function insertEvalCase(id: string, tenantId: string, agentName: string, data: {
+  question: string;
+  expectedTopics?: string[] | null;
+  expectedNotTopics?: string[] | null;
+  referenceAnswer?: string | null;
+  category?: string | null;
+  tags?: string[] | null;
+  chatHistory?: Array<{ role: string; content: string }> | null;
+  isActive?: boolean;
+}): Promise<EvalCase> {
+  return getDb().insertEvalCase(id, tenantId, agentName, data);
+}
+
+export async function getEvalCase(id: string): Promise<EvalCase | null> {
+  return getDb().getEvalCase(id);
+}
+
+export async function listEvalCases(tenantId: string, agentName: string, opts?: { category?: string; isActive?: boolean }): Promise<EvalCase[]> {
+  return getDb().listEvalCases(tenantId, agentName, opts);
+}
+
+export async function updateEvalCase(id: string, data: Partial<{
+  question: string;
+  expectedTopics: string[] | null;
+  expectedNotTopics: string[] | null;
+  referenceAnswer: string | null;
+  category: string | null;
+  tags: string[] | null;
+  chatHistory: Array<{ role: string; content: string }> | null;
+  isActive: boolean;
+}>): Promise<EvalCase | null> {
+  return getDb().updateEvalCase(id, data);
+}
+
+export async function deleteEvalCase(id: string): Promise<boolean> {
+  return getDb().deleteEvalCase(id);
+}
+
+// -- Eval Runs ----------------------------------------------------------------
+
+export async function insertEvalRun(id: string, tenantId: string, agentName: string, opts?: { versionNumber?: number; filters?: Record<string, unknown> }): Promise<EvalRun> {
+  return getDb().insertEvalRun(id, tenantId, agentName, opts);
+}
+
+export async function getEvalRun(id: string): Promise<EvalRun | null> {
+  return getDb().getEvalRun(id);
+}
+
+export async function listEvalRuns(tenantId: string, agentName: string): Promise<EvalRun[]> {
+  return getDb().listEvalRuns(tenantId, agentName);
+}
+
+export async function listPendingEvalRuns(): Promise<EvalRun[]> {
+  return getDb().listPendingEvalRuns();
+}
+
+export async function updateEvalRun(id: string, updates: Partial<{ status: EvalRunStatus; totalCases: number; completedCases: number; summary: EvalRunSummary | null; startedAt: string; completedAt: string }>): Promise<void> {
+  return getDb().updateEvalRun(id, updates);
+}
+
+// -- Eval Results -------------------------------------------------------------
+
+export async function insertEvalResult(id: string, tenantId: string, evalRunId: string, evalCaseId: string): Promise<EvalResult> {
+  return getDb().insertEvalResult(id, tenantId, evalRunId, evalCaseId);
+}
+
+export async function getEvalResult(id: string): Promise<EvalResult | null> {
+  return getDb().getEvalResult(id);
+}
+
+export async function listEvalResults(evalRunId: string): Promise<EvalResult[]> {
+  return getDb().listEvalResults(evalRunId);
+}
+
+export async function updateEvalResult(id: string, updates: Partial<{ agentResponse: string; topicScore: number; safetyScore: number; llmJudgeScore: number; latencyMs: number; status: EvalResultStatus; error: string; humanScore: number; humanNotes: string; completedAt: string }>): Promise<void> {
+  return getDb().updateEvalResult(id, updates);
 }
 
 export async function closeDb(): Promise<void> {

--- a/packages/server/src/db/schema.pg.ts
+++ b/packages/server/src/db/schema.pg.ts
@@ -20,11 +20,30 @@ export const agents = pgTable('agents', {
   version: integer('version').notNull().default(1),
   path: text('path').notNull(),
   env: text('env'),  // JSON blob of default env vars for sessions
+  activeVersionId: text('active_version_id'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
   uniqueIndex('idx_agents_tenant_name').on(table.tenantId, table.name),
   index('idx_agents_tenant').on(table.tenantId),
+]);
+
+export const agentVersions = pgTable('agent_versions', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  versionNumber: integer('version_number').notNull(),
+  name: text('name').notNull().default(''),
+  systemPrompt: text('system_prompt'),
+  releaseNotes: text('release_notes'),
+  isActive: integer('is_active').notNull().default(0),
+  knowledgeFiles: text('knowledge_files'),  // JSON array of file paths
+  createdBy: text('created_by'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  uniqueIndex('idx_agent_versions_unique').on(table.tenantId, table.agentName, table.versionNumber),
+  index('idx_agent_versions_active').on(table.tenantId, table.agentName, table.isActive),
 ]);
 
 export const sessions = pgTable('sessions', {
@@ -161,4 +180,62 @@ export const queueItems = pgTable('queue_items', {
 }, (table) => [
   index('idx_queue_tenant').on(table.tenantId),
   index('idx_queue_status').on(table.status, table.priority),
+]);
+
+export const evalCases = pgTable('eval_cases', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  question: text('question').notNull(),
+  expectedTopics: text('expected_topics'),      // JSON array
+  expectedNotTopics: text('expected_not_topics'), // JSON array
+  referenceAnswer: text('reference_answer'),
+  category: text('category'),
+  tags: text('tags'),                            // JSON array
+  chatHistory: text('chat_history'),             // JSON array of {role, content}
+  isActive: integer('is_active').notNull().default(1),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  index('idx_eval_cases_agent').on(table.tenantId, table.agentName),
+  index('idx_eval_cases_category').on(table.category),
+]);
+
+export const evalRuns = pgTable('eval_runs', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  versionNumber: integer('version_number'),
+  status: text('status').notNull().default('pending'),
+  totalCases: integer('total_cases').notNull().default(0),
+  completedCases: integer('completed_cases').notNull().default(0),
+  summary: text('summary'),     // JSON blob of EvalRunSummary
+  filters: text('filters'),     // JSON blob of run filters
+  createdAt: text('created_at').notNull(),
+  startedAt: text('started_at'),
+  completedAt: text('completed_at'),
+}, (table) => [
+  index('idx_eval_runs_agent').on(table.tenantId, table.agentName),
+  index('idx_eval_runs_status').on(table.status),
+]);
+
+export const evalResults = pgTable('eval_results', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  evalRunId: text('eval_run_id').notNull(),
+  evalCaseId: text('eval_case_id').notNull(),
+  agentResponse: text('agent_response'),
+  topicScore: real('topic_score'),
+  safetyScore: real('safety_score'),
+  llmJudgeScore: real('llm_judge_score'),
+  latencyMs: integer('latency_ms'),
+  status: text('status').notNull().default('pending'),
+  error: text('error'),
+  humanScore: real('human_score'),
+  humanNotes: text('human_notes'),
+  createdAt: text('created_at').notNull(),
+  completedAt: text('completed_at'),
+}, (table) => [
+  index('idx_eval_results_run').on(table.evalRunId),
+  index('idx_eval_results_case').on(table.evalCaseId),
 ]);

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -20,11 +20,30 @@ export const agents = sqliteTable('agents', {
   version: integer('version').notNull().default(1),
   path: text('path').notNull(),
   env: text('env'),  // JSON blob of default env vars for sessions
+  activeVersionId: text('active_version_id'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
   uniqueIndex('idx_agents_tenant_name').on(table.tenantId, table.name),
   index('idx_agents_tenant').on(table.tenantId),
+]);
+
+export const agentVersions = sqliteTable('agent_versions', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  versionNumber: integer('version_number').notNull(),
+  name: text('name').notNull().default(''),
+  systemPrompt: text('system_prompt'),
+  releaseNotes: text('release_notes'),
+  isActive: integer('is_active').notNull().default(0),
+  knowledgeFiles: text('knowledge_files'),  // JSON array of file paths
+  createdBy: text('created_by'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  uniqueIndex('idx_agent_versions_unique').on(table.tenantId, table.agentName, table.versionNumber),
+  index('idx_agent_versions_active').on(table.tenantId, table.agentName, table.isActive),
 ]);
 
 export const sessions = sqliteTable('sessions', {
@@ -161,4 +180,62 @@ export const queueItems = sqliteTable('queue_items', {
 }, (table) => [
   index('idx_queue_tenant').on(table.tenantId),
   index('idx_queue_status').on(table.status, table.priority),
+]);
+
+export const evalCases = sqliteTable('eval_cases', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  question: text('question').notNull(),
+  expectedTopics: text('expected_topics'),      // JSON array
+  expectedNotTopics: text('expected_not_topics'), // JSON array
+  referenceAnswer: text('reference_answer'),
+  category: text('category'),
+  tags: text('tags'),                            // JSON array
+  chatHistory: text('chat_history'),             // JSON array of {role, content}
+  isActive: integer('is_active').notNull().default(1),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  index('idx_eval_cases_agent').on(table.tenantId, table.agentName),
+  index('idx_eval_cases_category').on(table.category),
+]);
+
+export const evalRuns = sqliteTable('eval_runs', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  agentName: text('agent_name').notNull(),
+  versionNumber: integer('version_number'),
+  status: text('status').notNull().default('pending'),
+  totalCases: integer('total_cases').notNull().default(0),
+  completedCases: integer('completed_cases').notNull().default(0),
+  summary: text('summary'),     // JSON blob of EvalRunSummary
+  filters: text('filters'),     // JSON blob of run filters
+  createdAt: text('created_at').notNull(),
+  startedAt: text('started_at'),
+  completedAt: text('completed_at'),
+}, (table) => [
+  index('idx_eval_runs_agent').on(table.tenantId, table.agentName),
+  index('idx_eval_runs_status').on(table.status),
+]);
+
+export const evalResults = sqliteTable('eval_results', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().default('default'),
+  evalRunId: text('eval_run_id').notNull(),
+  evalCaseId: text('eval_case_id').notNull(),
+  agentResponse: text('agent_response'),
+  topicScore: real('topic_score'),
+  safetyScore: real('safety_score'),
+  llmJudgeScore: real('llm_judge_score'),
+  latencyMs: integer('latency_ms'),
+  status: text('status').notNull().default('pending'),
+  error: text('error'),
+  humanScore: real('human_score'),
+  humanNotes: text('human_notes'),
+  createdAt: text('created_at').notNull(),
+  completedAt: text('completed_at'),
+}, (table) => [
+  index('idx_eval_results_run').on(table.evalRunId),
+  index('idx_eval_results_case').on(table.evalCaseId),
 ]);

--- a/packages/server/src/eval/runner.ts
+++ b/packages/server/src/eval/runner.ts
@@ -1,0 +1,279 @@
+import {
+  getEvalRun,
+  listEvalResults,
+  getEvalCase,
+  updateEvalRun,
+  updateEvalResult,
+  getActiveAgentVersion,
+  getAgent,
+  listPendingEvalRuns,
+} from '../db/index.js';
+import { topicScore, safetyScore } from './scoring.js';
+import { extractTextFromEvent } from '@ash-ai/shared';
+import type { EvalRunSummary, EvalRun, EvalResult, EvalCase } from '@ash-ai/shared';
+import type { RunnerCoordinator } from '../runner/coordinator.js';
+import type { RunnerBackend } from '../runner/types.js';
+
+/**
+ * EvalRunner polls the DB for eval_runs with status='pending' and processes
+ * them by running each eval case against the agent, scoring the response,
+ * and updating results.
+ *
+ * Design notes:
+ * - Single-threaded per instance (guard flag prevents overlapping ticks)
+ * - Polls every 5 seconds for pending runs
+ * - Processes one run at a time, but all cases within a run sequentially
+ * - On failure mid-run, sets status='failed' with error info
+ * - Scoring is deterministic (topic/safety). LLM judge scoring is deferred.
+ */
+export class EvalRunner {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(
+    private coordinator: RunnerCoordinator,
+    private dataDir: string,
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.tick(), 5000);
+    console.log('[eval-runner] Started');
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      await this.processPendingRuns();
+    } catch (err) {
+      console.error('[eval-runner] Error:', err);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async processPendingRuns(): Promise<void> {
+    const pendingRuns = await listPendingEvalRuns();
+    for (const run of pendingRuns) {
+      await this.processRun(run.id);
+    }
+  }
+
+  async processRun(runId: string): Promise<void> {
+    const run = await getEvalRun(runId);
+    if (!run) {
+      console.error(`[eval-runner] Run ${runId} not found`);
+      return;
+    }
+    if (run.status !== 'pending') {
+      // Already picked up by another processor or manually updated
+      return;
+    }
+
+    // Transition to 'running'
+    const startedAt = new Date().toISOString();
+    await updateEvalRun(runId, { status: 'running', startedAt });
+
+    try {
+      // Resolve the agent so we can create sandboxes
+      const agent = await getAgent(run.agentName, run.tenantId);
+      if (!agent) {
+        throw new Error(`Agent '${run.agentName}' not found`);
+      }
+
+      // If the run targets a specific version, resolve the system prompt override
+      let systemPrompt: string | undefined;
+      if (run.versionNumber != null) {
+        const version = await getActiveAgentVersion(run.agentName, run.tenantId);
+        // Use the version's system prompt if available; otherwise fall back to agent default
+        if (version && version.systemPrompt) {
+          systemPrompt = version.systemPrompt;
+        }
+      }
+
+      // Get all results for this run
+      const results = await listEvalResults(runId);
+      let completedCases = 0;
+
+      for (const result of results) {
+        await this.processResult(result, agent.path, agent.name, systemPrompt);
+        completedCases++;
+        await updateEvalRun(runId, { completedCases });
+      }
+
+      // Compute summary metrics
+      const summary = await this.computeSummary(runId);
+
+      // Mark as completed
+      await updateEvalRun(runId, {
+        status: 'completed',
+        completedAt: new Date().toISOString(),
+        summary,
+      });
+
+      console.log(`[eval-runner] Run ${runId} completed: ${completedCases} cases`);
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      console.error(`[eval-runner] Run ${runId} failed:`, errorMsg);
+      await updateEvalRun(runId, {
+        status: 'failed',
+        completedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  private async processResult(
+    result: EvalResult,
+    agentDir: string,
+    agentName: string,
+    systemPrompt?: string,
+  ): Promise<void> {
+    const evalCase = await getEvalCase(result.evalCaseId);
+    if (!evalCase) {
+      await updateEvalResult(result.id, {
+        status: 'error',
+        error: `Eval case ${result.evalCaseId} not found`,
+        completedAt: new Date().toISOString(),
+      });
+      return;
+    }
+
+    // Mark result as running
+    await updateEvalResult(result.id, { status: 'running' });
+
+    const caseStartTime = Date.now();
+    let backend: RunnerBackend | undefined;
+    let sandboxId: string | undefined;
+
+    try {
+      // Select a backend and create a sandbox for this eval case
+      const selection = await this.coordinator.selectBackend();
+      backend = selection.backend;
+
+      const sessionId = `eval-${result.evalRunId}-${result.id}`;
+      const handle = await backend.createSandbox({
+        sessionId,
+        agentDir,
+        agentName,
+        sandboxId: sessionId,
+        ...(systemPrompt ? { systemPrompt } : {}),
+      });
+      sandboxId = handle.sandboxId;
+
+      // Send the question and collect the full response
+      const responseText = await this.queryAndCollect(backend, sandboxId, evalCase.question, sessionId);
+
+      const latencyMs = Date.now() - caseStartTime;
+
+      // Score the response
+      const tScore = topicScore(responseText, evalCase.expectedTopics ?? []);
+      const sScore = safetyScore(responseText, evalCase.expectedNotTopics ?? []);
+
+      // Update the result
+      await updateEvalResult(result.id, {
+        agentResponse: responseText,
+        topicScore: tScore,
+        safetyScore: sScore,
+        latencyMs,
+        status: 'completed',
+        completedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      await updateEvalResult(result.id, {
+        status: 'error',
+        error: errorMsg,
+        latencyMs: Date.now() - caseStartTime,
+        completedAt: new Date().toISOString(),
+      });
+    } finally {
+      // Clean up the sandbox
+      if (backend && sandboxId) {
+        try {
+          await backend.destroySandbox(sandboxId);
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    }
+  }
+
+  /**
+   * Send a query to the sandbox and collect the full text response.
+   * Iterates over all bridge events, extracting text from assistant messages.
+   */
+  private async queryAndCollect(
+    backend: RunnerBackend,
+    sandboxId: string,
+    question: string,
+    sessionId: string,
+  ): Promise<string> {
+    const events = backend.sendCommand(sandboxId, {
+      cmd: 'query',
+      prompt: question,
+      sessionId,
+    });
+
+    const textParts: string[] = [];
+
+    for await (const event of events) {
+      if (event.ev === 'message') {
+        const data = event.data as Record<string, any>;
+        const text = extractTextFromEvent(data);
+        if (text) {
+          textParts.push(text);
+        }
+      } else if (event.ev === 'error') {
+        throw new Error(`Bridge error: ${event.error}`);
+      }
+    }
+
+    return textParts.join('');
+  }
+
+  /**
+   * Compute summary metrics for a completed run.
+   * Reads all results and averages the scores.
+   */
+  private async computeSummary(runId: string): Promise<EvalRunSummary> {
+    const results = await listEvalResults(runId);
+    const completed = results.filter(r => r.status === 'completed');
+
+    if (completed.length === 0) {
+      return {
+        avgTopicScore: 0,
+        avgSafetyScore: 0,
+        avgLlmJudgeScore: null,
+        avgLatencyMs: 0,
+        passRate: 0,
+      };
+    }
+
+    const avgTopicScore = completed.reduce((sum, r) => sum + (r.topicScore ?? 0), 0) / completed.length;
+    const avgSafetyScore = completed.reduce((sum, r) => sum + (r.safetyScore ?? 0), 0) / completed.length;
+    const avgLatencyMs = completed.reduce((sum, r) => sum + (r.latencyMs ?? 0), 0) / completed.length;
+
+    // Pass rate: a case passes if both topic and safety scores are above 0.5
+    const passThreshold = 0.5;
+    const passed = completed.filter(r =>
+      (r.topicScore ?? 0) >= passThreshold && (r.safetyScore ?? 0) >= passThreshold
+    );
+    const passRate = passed.length / results.length;
+
+    return {
+      avgTopicScore,
+      avgSafetyScore,
+      avgLlmJudgeScore: null, // Deferred to future iteration
+      avgLatencyMs,
+      passRate,
+    };
+  }
+}

--- a/packages/server/src/eval/scoring.ts
+++ b/packages/server/src/eval/scoring.ts
@@ -1,0 +1,29 @@
+/**
+ * Scoring functions for evaluating agent responses against eval case expectations.
+ *
+ * These are deterministic, fast scoring functions that don't require LLM calls.
+ * LLM judge scoring is deferred to a future iteration.
+ */
+
+/**
+ * Calculate topic score: what fraction of expected topics appear in the response.
+ * Uses case-insensitive substring matching.
+ * Returns 0.0-1.0 (1.0 = all topics found).
+ */
+export function topicScore(response: string, expectedTopics: string[]): number {
+  if (!expectedTopics || expectedTopics.length === 0) return 1.0;
+  const lower = response.toLowerCase();
+  const hits = expectedTopics.filter(t => lower.includes(t.toLowerCase()));
+  return hits.length / expectedTopics.length;
+}
+
+/**
+ * Calculate safety score: what fraction of forbidden topics are absent.
+ * Returns 0.0-1.0 (1.0 = none of the bad topics appear).
+ */
+export function safetyScore(response: string, notTopics: string[]): number {
+  if (!notTopics || notTopics.length === 0) return 1.0;
+  const lower = response.toLowerCase();
+  const absent = notTopics.filter(t => !lower.includes(t.toLowerCase()));
+  return absent.length / notTopics.length;
+}

--- a/packages/server/src/routes/agent-versions.ts
+++ b/packages/server/src/routes/agent-versions.ts
@@ -1,0 +1,315 @@
+import type { FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import {
+  getAgent,
+  insertAgentVersion,
+  getAgentVersion,
+  getAgentVersionByNumber,
+  getActiveAgentVersion,
+  listAgentVersions,
+  activateAgentVersion,
+  getNextVersionNumber,
+  updateAgentVersion,
+  deleteAgentVersion,
+} from '../db/index.js';
+
+const nameParam = {
+  type: 'object',
+  properties: { name: { type: 'string' } },
+  required: ['name'],
+} as const;
+
+const nameAndVersionParams = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    versionNumber: { type: 'string' },
+  },
+  required: ['name', 'versionNumber'],
+} as const;
+
+const agentVersionObject = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    tenantId: { type: 'string' },
+    agentName: { type: 'string' },
+    versionNumber: { type: 'integer' },
+    name: { type: 'string' },
+    systemPrompt: { type: ['string', 'null'] },
+    releaseNotes: { type: ['string', 'null'] },
+    isActive: { type: 'boolean' },
+    knowledgeFiles: {
+      type: ['array', 'null'],
+      items: { type: 'string' },
+    },
+    createdBy: { type: ['string', 'null'] },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'agentName', 'versionNumber', 'name', 'isActive', 'createdAt', 'updatedAt'],
+} as const;
+
+export function agentVersionRoutes(app: FastifyInstance): void {
+  // List versions for an agent
+  app.get<{ Params: { name: string } }>('/api/agents/:name/versions', {
+    schema: {
+      tags: ['agents'],
+      params: nameParam,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            versions: { type: 'array', items: agentVersionObject },
+          },
+          required: ['versions'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const versions = await listAgentVersions(req.params.name, req.tenantId);
+    return reply.send({ versions });
+  });
+
+  // Create a new version for an agent
+  app.post<{ Params: { name: string } }>('/api/agents/:name/versions', {
+    schema: {
+      tags: ['agents'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', maxLength: 255 },
+          systemPrompt: { type: 'string', maxLength: 1_000_000 },
+          releaseNotes: { type: 'string', maxLength: 10_000 },
+          knowledgeFiles: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          cloneFrom: { type: 'integer', minimum: 1 },
+        },
+      },
+      response: {
+        201: {
+          type: 'object',
+          properties: { version: agentVersionObject },
+          required: ['version'],
+        },
+        404: { $ref: 'ApiError#' },
+        400: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const body = req.body as {
+      name?: string;
+      systemPrompt?: string;
+      releaseNotes?: string;
+      knowledgeFiles?: string[];
+      cloneFrom?: number;
+    } | undefined;
+
+    let systemPrompt = body?.systemPrompt ?? null;
+    let knowledgeFiles = body?.knowledgeFiles ?? null;
+
+    // If cloneFrom is specified, copy systemPrompt and knowledgeFiles from that version
+    if (body?.cloneFrom != null) {
+      const sourceVersion = await getAgentVersionByNumber(req.params.name, body.cloneFrom, req.tenantId);
+      if (!sourceVersion) {
+        return reply.status(400).send({ error: `Source version ${body.cloneFrom} not found`, statusCode: 400 });
+      }
+      systemPrompt = systemPrompt ?? sourceVersion.systemPrompt;
+      knowledgeFiles = knowledgeFiles ?? sourceVersion.knowledgeFiles;
+    }
+
+    const versionNumber = await getNextVersionNumber(req.params.name, req.tenantId);
+    const id = randomUUID();
+    const versionName = body?.name ?? `v${versionNumber}`;
+
+    const version = await insertAgentVersion(id, req.tenantId, req.params.name, versionNumber, {
+      name: versionName,
+      systemPrompt,
+      releaseNotes: body?.releaseNotes ?? null,
+      knowledgeFiles,
+    });
+
+    return reply.status(201).send({ version });
+  });
+
+  // Get a specific version by version number
+  app.get<{ Params: { name: string; versionNumber: string } }>('/api/agents/:name/versions/:versionNumber', {
+    schema: {
+      tags: ['agents'],
+      params: nameAndVersionParams,
+      response: {
+        200: {
+          type: 'object',
+          properties: { version: agentVersionObject },
+          required: ['version'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const versionNumber = parseInt(req.params.versionNumber, 10);
+    if (isNaN(versionNumber)) {
+      return reply.status(400).send({ error: 'Invalid version number', statusCode: 400 });
+    }
+
+    const version = await getAgentVersionByNumber(req.params.name, versionNumber, req.tenantId);
+    if (!version) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    return reply.send({ version });
+  });
+
+  // Update a version
+  app.patch<{ Params: { name: string; versionNumber: string } }>('/api/agents/:name/versions/:versionNumber', {
+    schema: {
+      tags: ['agents'],
+      params: nameAndVersionParams,
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', maxLength: 255 },
+          systemPrompt: { type: 'string', maxLength: 1_000_000 },
+          releaseNotes: { type: 'string', maxLength: 10_000 },
+          knowledgeFiles: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: { version: agentVersionObject },
+          required: ['version'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const versionNumber = parseInt(req.params.versionNumber, 10);
+    if (isNaN(versionNumber)) {
+      return reply.status(400).send({ error: 'Invalid version number', statusCode: 400 });
+    }
+
+    const existing = await getAgentVersionByNumber(req.params.name, versionNumber, req.tenantId);
+    if (!existing) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    const body = req.body as {
+      name?: string;
+      systemPrompt?: string;
+      releaseNotes?: string;
+      knowledgeFiles?: string[];
+    } | undefined;
+
+    const updated = await updateAgentVersion(existing.id, {
+      name: body?.name,
+      systemPrompt: body?.systemPrompt,
+      releaseNotes: body?.releaseNotes,
+      knowledgeFiles: body?.knowledgeFiles,
+    });
+
+    if (!updated) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    return reply.send({ version: updated });
+  });
+
+  // Delete a version
+  app.delete<{ Params: { name: string; versionNumber: string } }>('/api/agents/:name/versions/:versionNumber', {
+    schema: {
+      tags: ['agents'],
+      params: nameAndVersionParams,
+      response: {
+        204: { type: 'null', description: 'Version deleted' },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const versionNumber = parseInt(req.params.versionNumber, 10);
+    if (isNaN(versionNumber)) {
+      return reply.status(400).send({ error: 'Invalid version number', statusCode: 400 });
+    }
+
+    const existing = await getAgentVersionByNumber(req.params.name, versionNumber, req.tenantId);
+    if (!existing) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    const deleted = await deleteAgentVersion(existing.id);
+    if (!deleted) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    return reply.status(204).send();
+  });
+
+  // Activate a version
+  app.post<{ Params: { name: string; versionNumber: string } }>('/api/agents/:name/versions/:versionNumber/activate', {
+    schema: {
+      tags: ['agents'],
+      params: nameAndVersionParams,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            activated: { type: 'boolean' },
+            versionNumber: { type: 'integer' },
+          },
+          required: ['activated', 'versionNumber'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const versionNumber = parseInt(req.params.versionNumber, 10);
+    if (isNaN(versionNumber)) {
+      return reply.status(400).send({ error: 'Invalid version number', statusCode: 400 });
+    }
+
+    const version = await getAgentVersionByNumber(req.params.name, versionNumber, req.tenantId);
+    if (!version) {
+      return reply.status(404).send({ error: 'Version not found', statusCode: 404 });
+    }
+
+    await activateAgentVersion(version.id, req.params.name, req.tenantId);
+    return reply.send({ activated: true, versionNumber });
+  });
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { existsSync, readdirSync, statSync, readFileSync, createReadStream, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, statSync, readFileSync, createReadStream, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join, isAbsolute, relative, basename, extname, dirname, resolve, sep } from 'node:path';
 import { upsertAgent, getAgent, listAgents, updateAgent, deleteAgent } from '../db/index.js';
 import type { FileEntry } from '@ash-ai/shared';
@@ -391,5 +391,69 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
       .header('Content-Disposition', `attachment; filename*=UTF-8''${encodeURIComponent(fileName)}`)
       .header('Content-Length', st.size);
     return reply.send(createReadStream(fullPath));
+  });
+
+  // Upload/write files to agent directory
+  app.post<{ Params: { name: string }; Body: { files: Array<{ path: string; content: string }> } }>('/api/agents/:name/files', {
+    schema: {
+      tags: ['agents'],
+      params: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+      body: {
+        type: 'object',
+        properties: {
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { path: { type: 'string' }, content: { type: 'string' } },
+              required: ['path', 'content'],
+            },
+          },
+        },
+        required: ['files'],
+      },
+      response: { 200: { type: 'object', properties: { written: { type: 'integer' } } } },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+
+    const { files } = req.body;
+    let written = 0;
+    for (const file of files) {
+      const targetPath = join(agent.path, file.path);
+      // Security: ensure the resolved path is within the agent directory
+      const resolved = resolve(targetPath);
+      if (!resolved.startsWith(resolve(agent.path))) {
+        return reply.status(400).send({ error: `Path "${file.path}" escapes agent directory`, statusCode: 400 });
+      }
+      mkdirSync(dirname(resolved), { recursive: true });
+      writeFileSync(resolved, Buffer.from(file.content, 'base64'));
+      written++;
+    }
+    return reply.send({ written });
+  });
+
+  // Delete a file from agent directory
+  app.delete<{ Params: { name: string; '*': string } }>('/api/agents/:name/files/*', {
+    schema: {
+      tags: ['agents'],
+      params: { type: 'object', properties: { name: { type: 'string' }, '*': { type: 'string' } }, required: ['name', '*'] },
+      response: { 200: { type: 'object', properties: { deleted: { type: 'boolean' } } } },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+
+    const filePath = req.params['*'];
+    const targetPath = resolve(join(agent.path, filePath));
+    if (!targetPath.startsWith(resolve(agent.path))) {
+      return reply.status(400).send({ error: 'Path escapes agent directory', statusCode: 400 });
+    }
+    if (!existsSync(targetPath)) {
+      return reply.status(404).send({ error: 'File not found', statusCode: 404 });
+    }
+    unlinkSync(targetPath);
+    return reply.send({ deleted: true });
   });
 }

--- a/packages/server/src/routes/evals.ts
+++ b/packages/server/src/routes/evals.ts
@@ -1,0 +1,602 @@
+import type { FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+import {
+  getAgent,
+  insertEvalCase,
+  getEvalCase,
+  listEvalCases,
+  updateEvalCase,
+  deleteEvalCase,
+  insertEvalRun,
+  getEvalRun,
+  listEvalRuns,
+  updateEvalRun,
+  insertEvalResult,
+  listEvalResults,
+  listAgentVersions,
+  getAgentVersionByNumber,
+} from '../db/index.js';
+import type { RunnerCoordinator } from '../runner/coordinator.js';
+import type { TelemetryExporter } from '../telemetry/exporter.js';
+
+const nameParam = {
+  type: 'object',
+  properties: { name: { type: 'string' } },
+  required: ['name'],
+} as const;
+
+const nameAndIdParams = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    id: { type: 'string', format: 'uuid' },
+  },
+  required: ['name', 'id'],
+} as const;
+
+const chatHistoryItemSchema = {
+  type: 'object',
+  properties: {
+    role: { type: 'string' },
+    content: { type: 'string' },
+  },
+  required: ['role', 'content'],
+} as const;
+
+const evalCaseBodyProperties = {
+  question: { type: 'string', minLength: 1 },
+  expectedTopics: { type: 'array', items: { type: 'string' }, nullable: true },
+  expectedNotTopics: { type: 'array', items: { type: 'string' }, nullable: true },
+  referenceAnswer: { type: 'string', nullable: true },
+  category: { type: 'string', nullable: true },
+  tags: { type: 'array', items: { type: 'string' }, nullable: true },
+  chatHistory: { type: 'array', items: chatHistoryItemSchema, nullable: true },
+  isActive: { type: 'boolean' },
+} as const;
+
+export function evalRoutes(
+  app: FastifyInstance,
+  _coordinator: RunnerCoordinator,
+  _dataDir: string,
+  _telemetry: TelemetryExporter | null,
+): void {
+  // ── Eval Cases CRUD ─────────────────────────────────────────────────────
+
+  // Import cases (bulk create) — registered BEFORE :id to avoid "import" matching as :id
+  app.post<{ Params: { name: string } }>('/api/agents/:name/eval-cases/import', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        properties: {
+          cases: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: evalCaseBodyProperties,
+              required: ['question'],
+            },
+          },
+        },
+        required: ['cases'],
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: { imported: { type: 'integer' } },
+          required: ['imported'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const { cases } = req.body as {
+      cases: Array<{
+        question: string;
+        expectedTopics?: string[];
+        expectedNotTopics?: string[];
+        referenceAnswer?: string;
+        category?: string;
+        tags?: string[];
+        chatHistory?: Array<{ role: string; content: string }>;
+        isActive?: boolean;
+      }>;
+    };
+
+    let imported = 0;
+    for (const c of cases) {
+      await insertEvalCase(randomUUID(), req.tenantId, agent.name, {
+        question: c.question,
+        expectedTopics: c.expectedTopics ?? null,
+        expectedNotTopics: c.expectedNotTopics ?? null,
+        referenceAnswer: c.referenceAnswer ?? null,
+        category: c.category ?? null,
+        tags: c.tags ?? null,
+        chatHistory: c.chatHistory ?? null,
+        isActive: c.isActive ?? true,
+      });
+      imported++;
+    }
+
+    return reply.send({ imported });
+  });
+
+  // Export cases — registered BEFORE :id to avoid "export" matching as :id
+  app.get<{ Params: { name: string } }>('/api/agents/:name/eval-cases/export', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            cases: { type: 'array' },
+          },
+          required: ['cases'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const cases = await listEvalCases(req.tenantId, agent.name);
+    return reply.send({ cases });
+  });
+
+  // List eval cases
+  app.get<{ Params: { name: string }; Querystring: { category?: string; isActive?: string } }>('/api/agents/:name/eval-cases', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      querystring: {
+        type: 'object',
+        properties: {
+          category: { type: 'string' },
+          isActive: { type: 'string', enum: ['true', 'false'] },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            cases: { type: 'array' },
+          },
+          required: ['cases'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const { category, isActive } = req.query;
+    const opts: { category?: string; isActive?: boolean } = {};
+    if (category) opts.category = category;
+    if (isActive !== undefined) opts.isActive = isActive === 'true';
+
+    const cases = await listEvalCases(req.tenantId, agent.name, opts);
+    return reply.send({ cases });
+  });
+
+  // Create eval case
+  app.post<{ Params: { name: string } }>('/api/agents/:name/eval-cases', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        properties: evalCaseBodyProperties,
+        required: ['question'],
+      },
+      response: {
+        201: {
+          type: 'object',
+          properties: { case: { type: 'object' } },
+          required: ['case'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const body = req.body as {
+      question: string;
+      expectedTopics?: string[];
+      expectedNotTopics?: string[];
+      referenceAnswer?: string;
+      category?: string;
+      tags?: string[];
+      chatHistory?: Array<{ role: string; content: string }>;
+      isActive?: boolean;
+    };
+
+    const evalCase = await insertEvalCase(randomUUID(), req.tenantId, agent.name, {
+      question: body.question,
+      expectedTopics: body.expectedTopics ?? null,
+      expectedNotTopics: body.expectedNotTopics ?? null,
+      referenceAnswer: body.referenceAnswer ?? null,
+      category: body.category ?? null,
+      tags: body.tags ?? null,
+      chatHistory: body.chatHistory ?? null,
+      isActive: body.isActive ?? true,
+    });
+
+    return reply.status(201).send({ case: evalCase });
+  });
+
+  // Get eval case
+  app.get<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-cases/:id', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      response: {
+        200: {
+          type: 'object',
+          properties: { case: { type: 'object' } },
+          required: ['case'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const evalCase = await getEvalCase(req.params.id);
+    if (!evalCase || evalCase.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval case not found', statusCode: 404 });
+    }
+
+    return reply.send({ case: evalCase });
+  });
+
+  // Update eval case
+  app.patch<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-cases/:id', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      body: {
+        type: 'object',
+        properties: evalCaseBodyProperties,
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: { case: { type: 'object' } },
+          required: ['case'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const existing = await getEvalCase(req.params.id);
+    if (!existing || existing.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval case not found', statusCode: 404 });
+    }
+
+    const body = req.body as Partial<{
+      question: string;
+      expectedTopics: string[] | null;
+      expectedNotTopics: string[] | null;
+      referenceAnswer: string | null;
+      category: string | null;
+      tags: string[] | null;
+      chatHistory: Array<{ role: string; content: string }> | null;
+      isActive: boolean;
+    }>;
+
+    const updated = await updateEvalCase(req.params.id, body);
+    if (!updated) {
+      return reply.status(404).send({ error: 'Eval case not found', statusCode: 404 });
+    }
+
+    return reply.send({ case: updated });
+  });
+
+  // Delete eval case
+  app.delete<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-cases/:id', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      response: {
+        204: { type: 'null', description: 'No content' },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const existing = await getEvalCase(req.params.id);
+    if (!existing || existing.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval case not found', statusCode: 404 });
+    }
+
+    await deleteEvalCase(req.params.id);
+    return reply.status(204).send();
+  });
+
+  // ── Eval Runs ───────────────────────────────────────────────────────────
+
+  // Compare runs — registered BEFORE :id to avoid "compare" matching as :id
+  app.get<{ Params: { name: string }; Querystring: { runA: string; runB: string } }>('/api/agents/:name/eval-runs/compare', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      querystring: {
+        type: 'object',
+        properties: {
+          runA: { type: 'string', format: 'uuid' },
+          runB: { type: 'string', format: 'uuid' },
+        },
+        required: ['runA', 'runB'],
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            comparison: {
+              type: 'object',
+              properties: {
+                runA: { type: 'object' },
+                runB: { type: 'object' },
+                results: { type: 'array' },
+              },
+              required: ['runA', 'runB', 'results'],
+            },
+          },
+          required: ['comparison'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const { runA: runAId, runB: runBId } = req.query;
+
+    const runA = await getEvalRun(runAId);
+    if (!runA || runA.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval run A not found', statusCode: 404 });
+    }
+
+    const runB = await getEvalRun(runBId);
+    if (!runB || runB.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval run B not found', statusCode: 404 });
+    }
+
+    const resultsA = await listEvalResults(runAId);
+    const resultsB = await listEvalResults(runBId);
+
+    // Build a map of caseId -> result for each run
+    const mapA = new Map(resultsA.map(r => [r.evalCaseId, r]));
+    const mapB = new Map(resultsB.map(r => [r.evalCaseId, r]));
+
+    // Collect all unique case IDs
+    const allCaseIds = new Set([...mapA.keys(), ...mapB.keys()]);
+
+    // Build paired results, resolving the question from each eval case
+    const pairedResults: Array<{
+      caseId: string;
+      question: string;
+      resultA: typeof resultsA[number] | null;
+      resultB: typeof resultsB[number] | null;
+    }> = [];
+
+    for (const caseId of allCaseIds) {
+      const evalCase = await getEvalCase(caseId);
+      pairedResults.push({
+        caseId,
+        question: evalCase?.question ?? '',
+        resultA: mapA.get(caseId) ?? null,
+        resultB: mapB.get(caseId) ?? null,
+      });
+    }
+
+    return reply.send({
+      comparison: {
+        runA,
+        runB,
+        results: pairedResults,
+      },
+    });
+  });
+
+  // Create eval run
+  app.post<{ Params: { name: string } }>('/api/agents/:name/eval-runs', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        properties: {
+          versionNumber: { type: 'integer' },
+          categories: { type: 'array', items: { type: 'string' } },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+      },
+      response: {
+        201: {
+          type: 'object',
+          properties: { run: { type: 'object' } },
+          required: ['run'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const body = req.body as {
+      versionNumber?: number;
+      categories?: string[];
+      tags?: string[];
+    } | undefined;
+
+    const versionNumber = body?.versionNumber;
+
+    // If a versionNumber is specified, verify it exists
+    if (versionNumber !== undefined) {
+      const version = await getAgentVersionByNumber(agent.name, versionNumber, req.tenantId);
+      if (!version) {
+        return reply.status(404).send({ error: `Agent version ${versionNumber} not found`, statusCode: 404 });
+      }
+    }
+
+    // Fetch matching active eval cases
+    let cases = await listEvalCases(req.tenantId, agent.name, { isActive: true });
+
+    // Filter by categories if provided
+    if (body?.categories && body.categories.length > 0) {
+      const categorySet = new Set(body.categories);
+      cases = cases.filter(c => c.category !== null && categorySet.has(c.category));
+    }
+
+    // Filter by tags if provided
+    if (body?.tags && body.tags.length > 0) {
+      const tagSet = new Set(body.tags);
+      cases = cases.filter(c => c.tags !== null && c.tags.some(t => tagSet.has(t)));
+    }
+
+    // Create the eval run
+    const runId = randomUUID();
+    const filters: Record<string, unknown> = {};
+    if (body?.categories) filters.categories = body.categories;
+    if (body?.tags) filters.tags = body.tags;
+
+    const run = await insertEvalRun(runId, req.tenantId, agent.name, {
+      versionNumber,
+      filters: Object.keys(filters).length > 0 ? filters : undefined,
+    });
+
+    // Update total cases count
+    await updateEvalRun(runId, { totalCases: cases.length });
+
+    // Create a pending eval_result entry for each matching case
+    for (const evalCase of cases) {
+      await insertEvalResult(randomUUID(), req.tenantId, runId, evalCase.id);
+    }
+
+    // Re-fetch run to include updated totalCases
+    const updatedRun = await getEvalRun(runId);
+
+    return reply.status(201).send({ run: updatedRun ?? run });
+  });
+
+  // List eval runs
+  app.get<{ Params: { name: string } }>('/api/agents/:name/eval-runs', {
+    schema: {
+      tags: ['evals'],
+      params: nameParam,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            runs: { type: 'array' },
+          },
+          required: ['runs'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const runs = await listEvalRuns(req.tenantId, agent.name);
+    return reply.send({ runs });
+  });
+
+  // Get eval run
+  app.get<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-runs/:id', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      response: {
+        200: {
+          type: 'object',
+          properties: { run: { type: 'object' } },
+          required: ['run'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const run = await getEvalRun(req.params.id);
+    if (!run || run.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval run not found', statusCode: 404 });
+    }
+
+    return reply.send({ run });
+  });
+
+  // Get eval run results
+  app.get<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-runs/:id/results', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            results: { type: 'array' },
+          },
+          required: ['results'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const run = await getEvalRun(req.params.id);
+    if (!run || run.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval run not found', statusCode: 404 });
+    }
+
+    const results = await listEvalResults(req.params.id);
+    return reply.send({ results });
+  });
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { SSE_WRITE_TIMEOUT_MS, timingEnabled, startTimer, logTiming, type SessionConfig } from '@ash-ai/shared';
-import { getAgent, insertSession, insertForkedSession, getSession, listSessions, updateSessionStatus, updateSessionSandbox, updateSessionConfig, touchSession, updateSessionRunner, insertMessage, listMessages, insertSessionEvent, insertSessionEvents, listSessionEvents } from '../db/index.js';
+import { getAgent, getActiveAgentVersion, insertSession, insertForkedSession, getSession, listSessions, updateSessionStatus, updateSessionSandbox, updateSessionConfig, touchSession, updateSessionRunner, insertMessage, listMessages, insertSessionEvent, insertSessionEvents, listSessionEvents } from '../db/index.js';
 import { classifyBridgeMessage, classifyToStreamEvents } from '@ash-ai/shared';
 import { VERSION } from '../version.js';
 import type { RunnerCoordinator } from '../runner/coordinator.js';
@@ -141,6 +141,15 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
       console.log(`[sessions] Restored agent "${agent}" from cloud storage`);
     }
 
+    // Resolve system prompt: request override > active version > on-disk CLAUDE.md
+    let effectiveSystemPrompt = systemPrompt; // from request body
+    if (!effectiveSystemPrompt) {
+      const activeVersion = await getActiveAgentVersion(agentRecord.name, req.tenantId);
+      if (activeVersion?.systemPrompt) {
+        effectiveSystemPrompt = activeVersion.systemPrompt;
+      }
+    }
+
     // Build extraEnv with merge order: agent.env → credential env → session extraEnv → ASH_PERMISSION_MODE
     let extraEnv: Record<string, string> | undefined;
 
@@ -210,7 +219,7 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
         sandboxId: sessionId,
         extraEnv,
         mcpServers,
-        systemPrompt,
+        systemPrompt: effectiveSystemPrompt,
         onOomKill: () => {
           updateSessionStatus(sessionId, 'paused').catch((err) =>
             console.error(`Failed to update session status on OOM: ${err}`)

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -191,6 +191,85 @@ const UsageStatsSchema = {
   required: ['totalInputTokens', 'totalOutputTokens', 'totalCacheCreationTokens', 'totalCacheReadTokens', 'totalToolCalls', 'totalMessages', 'totalComputeSeconds'],
 } as const;
 
+const AgentVersionSchema = {
+  $id: 'AgentVersion',
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    tenantId: { type: 'string' },
+    agentName: { type: 'string' },
+    versionNumber: { type: 'integer' },
+    name: { type: 'string' },
+    systemPrompt: { type: 'string', nullable: true },
+    releaseNotes: { type: 'string', nullable: true },
+    isActive: { type: 'boolean' },
+    knowledgeFiles: { type: 'array', items: { type: 'string' }, nullable: true },
+    createdBy: { type: 'string', nullable: true },
+    createdAt: { type: 'string' },
+    updatedAt: { type: 'string' },
+  },
+} as const;
+
+const EvalCaseSchema = {
+  $id: 'EvalCase',
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    tenantId: { type: 'string' },
+    agentName: { type: 'string' },
+    question: { type: 'string' },
+    expectedTopics: { type: 'array', items: { type: 'string' }, nullable: true },
+    expectedNotTopics: { type: 'array', items: { type: 'string' }, nullable: true },
+    referenceAnswer: { type: 'string', nullable: true },
+    category: { type: 'string', nullable: true },
+    tags: { type: 'array', items: { type: 'string' }, nullable: true },
+    chatHistory: { type: 'array', items: { type: 'object' }, nullable: true },
+    isActive: { type: 'boolean' },
+    createdAt: { type: 'string' },
+    updatedAt: { type: 'string' },
+  },
+} as const;
+
+const EvalRunSchema = {
+  $id: 'EvalRun',
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    tenantId: { type: 'string' },
+    agentName: { type: 'string' },
+    versionNumber: { type: 'integer', nullable: true },
+    status: { type: 'string', enum: ['pending', 'running', 'completed', 'failed'] },
+    totalCases: { type: 'integer' },
+    completedCases: { type: 'integer' },
+    summary: { type: 'object', nullable: true },
+    createdAt: { type: 'string' },
+    startedAt: { type: 'string', nullable: true },
+    completedAt: { type: 'string', nullable: true },
+  },
+} as const;
+
+const EvalResultSchema = {
+  $id: 'EvalResult',
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    tenantId: { type: 'string' },
+    evalRunId: { type: 'string', format: 'uuid' },
+    evalCaseId: { type: 'string', format: 'uuid' },
+    agentResponse: { type: 'string', nullable: true },
+    topicScore: { type: 'number', nullable: true },
+    safetyScore: { type: 'number', nullable: true },
+    llmJudgeScore: { type: 'number', nullable: true },
+    latencyMs: { type: 'integer', nullable: true },
+    status: { type: 'string', enum: ['pending', 'running', 'completed', 'error'] },
+    error: { type: 'string', nullable: true },
+    humanScore: { type: 'number', nullable: true },
+    humanNotes: { type: 'string', nullable: true },
+    createdAt: { type: 'string' },
+    completedAt: { type: 'string', nullable: true },
+  },
+} as const;
+
 export function registerSchemas(app: FastifyInstance): void {
   app.addSchema(AgentSchema);
   app.addSchema(SessionSchema);
@@ -204,4 +283,8 @@ export function registerSchemas(app: FastifyInstance): void {
   app.addSchema(CredentialSchema);
   app.addSchema(UsageEventSchema);
   app.addSchema(UsageStatsSchema);
+  app.addSchema(AgentVersionSchema);
+  app.addSchema(EvalCaseSchema);
+  app.addSchema(EvalRunSchema);
+  app.addSchema(EvalResultSchema);
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -30,6 +30,9 @@ import { attachmentRoutes } from './routes/attachments.js';
 import { usageRoutes } from './routes/usage.js';
 import { workspaceRoutes } from './routes/workspace.js';
 import { apiKeyRoutes } from './routes/api-keys.js';
+import { agentVersionRoutes } from './routes/agent-versions.js';
+import { evalRoutes } from './routes/evals.js';
+import { EvalRunner } from './eval/runner.js';
 import { createTelemetryExporter } from './telemetry/exporter.js';
 import { VERSION } from './version.js';
 
@@ -168,6 +171,7 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
         { name: 'attachments', description: 'File attachments for sessions' },
         { name: 'queue', description: 'Async message queue' },
         { name: 'usage', description: 'Usage tracking and analytics' },
+        { name: 'evals', description: 'Evaluation framework' },
       ],
     },
   });
@@ -231,6 +235,8 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
   healthRoutes(app, coordinator, pool);
   runnerRoutes(app, coordinator);
   apiKeyRoutes(app, opts.apiKey);
+  agentVersionRoutes(app);
+  evalRoutes(app, coordinator, dataDir, telemetry);
 
   // Dashboard config endpoint — always registered so the dev proxy can reach it.
   // Includes serverUrl so the dashboard SDK client talks directly to the Ash server,
@@ -325,10 +331,14 @@ export async function createAshServer(opts: AshServerOptions = {}): Promise<AshS
   });
   queueProcessor.start();
 
+  const evalRunner = new EvalRunner(coordinator, dataDir);
+  evalRunner.start();
+
   // Shutdown handler
   async function shutdown() {
     app.log.info('Shutting down...');
     queueProcessor.stop();
+    evalRunner.stop();
     await telemetry.shutdown();
     coordinator.stopLivenessSweep();
     if (pool) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -544,6 +544,151 @@ export interface ListQueueResponse {
   items: QueueItem[];
 }
 
+// -- Agent Versions -----------------------------------------------------------
+
+export interface AgentVersion {
+  id: string;
+  tenantId?: string;
+  agentName: string;
+  versionNumber: number;
+  name: string;
+  systemPrompt: string | null;
+  releaseNotes: string | null;
+  isActive: boolean;
+  knowledgeFiles: string[] | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAgentVersionRequest {
+  /** Human-readable version name (e.g. "v2 - improved grounding"). */
+  name?: string;
+  /** System prompt snapshot for this version. */
+  systemPrompt?: string;
+  /** What changed in this version. */
+  releaseNotes?: string;
+  /** List of knowledge base file paths included in this version. */
+  knowledgeFiles?: string[];
+  /** Version number to clone from (copies systemPrompt and knowledgeFiles). */
+  cloneFrom?: number;
+}
+
+export interface UpdateAgentVersionRequest {
+  name?: string;
+  systemPrompt?: string;
+  releaseNotes?: string;
+  knowledgeFiles?: string[];
+}
+
+export interface ListAgentVersionsResponse {
+  versions: AgentVersion[];
+}
+
+// -- Eval Framework -----------------------------------------------------------
+
+export type EvalCaseCategory = 'accuracy' | 'groundedness' | 'safety' | 'edge_case' | 'multi_turn' | string;
+
+export interface EvalCase {
+  id: string;
+  tenantId?: string;
+  agentName: string;
+  question: string;
+  expectedTopics: string[] | null;
+  expectedNotTopics: string[] | null;
+  referenceAnswer: string | null;
+  category: EvalCaseCategory | null;
+  tags: string[] | null;
+  chatHistory: Array<{ role: string; content: string }> | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type EvalRunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface EvalRunSummary {
+  avgTopicScore: number;
+  avgSafetyScore: number;
+  avgLlmJudgeScore: number | null;
+  avgLatencyMs: number;
+  passRate: number;
+}
+
+export interface EvalRun {
+  id: string;
+  tenantId?: string;
+  agentName: string;
+  versionNumber: number | null;
+  status: EvalRunStatus;
+  totalCases: number;
+  completedCases: number;
+  summary: EvalRunSummary | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export type EvalResultStatus = 'pending' | 'running' | 'completed' | 'error';
+
+export interface EvalResult {
+  id: string;
+  tenantId?: string;
+  evalRunId: string;
+  evalCaseId: string;
+  agentResponse: string | null;
+  topicScore: number | null;
+  safetyScore: number | null;
+  llmJudgeScore: number | null;
+  latencyMs: number | null;
+  status: EvalResultStatus;
+  error: string | null;
+  humanScore: number | null;
+  humanNotes: string | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+export interface CreateEvalCaseRequest {
+  question: string;
+  expectedTopics?: string[];
+  expectedNotTopics?: string[];
+  referenceAnswer?: string;
+  category?: EvalCaseCategory;
+  tags?: string[];
+  chatHistory?: Array<{ role: string; content: string }>;
+  isActive?: boolean;
+}
+
+export interface CreateEvalRunRequest {
+  versionNumber?: number;
+  categories?: string[];
+  tags?: string[];
+}
+
+export interface ListEvalCasesResponse {
+  cases: EvalCase[];
+}
+
+export interface ListEvalRunsResponse {
+  runs: EvalRun[];
+}
+
+export interface ListEvalResultsResponse {
+  results: EvalResult[];
+}
+
+export interface EvalRunComparison {
+  runA: EvalRun;
+  runB: EvalRun;
+  results: Array<{
+    caseId: string;
+    question: string;
+    resultA: EvalResult | null;
+    resultB: EvalResult | null;
+  }>;
+}
+
 // -- API request/response -----------------------------------------------------
 
 /** MCP server configuration for .mcp.json entries. */


### PR DESCRIPTION
## Summary

Closes #84

- **Agent Versioning**: Version agent configurations with immutable system prompt snapshots. Supports create, clone-from, activate/rollback. Session creation resolves system prompt via: request override > active version > on-disk CLAUDE.md.
- **Eval Framework**: Define eval cases with expected topics and safety constraints. Run batch evaluations that create real agent sessions, score responses (topic hit rate, safety score), and compare runs side-by-side.
- **Knowledge Base Management**: Upload/delete agent files via API, associate files with specific versions via JSON array on `agent_versions`.

### Stack changes
| Layer | Changes |
|-------|---------|
| **Shared types** | `AgentVersion`, `EvalCase`, `EvalRun`, `EvalResult` + request/response types |
| **DB schema** | 4 new tables (`agent_versions`, `eval_cases`, `eval_runs`, `eval_results`), `active_version_id` on `agents` |
| **Migrations** | SQLite `0011` + PostgreSQL `0011` |
| **Server routes** | 6 version endpoints, 14 eval endpoints, 2 file management endpoints |
| **Eval engine** | `EvalRunner` (polling processor) + `scoring.ts` (topic/safety scoring) |
| **Session integration** | Active version system prompt resolution in session creation |
| **SDK client** | 20 new methods (versions, files, eval cases, eval runs) |
| **Dashboard** | 7 new pages: agent detail, versions, knowledge, evals, eval runs, run detail, run comparison |

## Test plan

- [x] `pnpm build` passes (all packages including dashboard static export)
- [x] `pnpm test` passes (257/257 tests, 23 test files)
- [x] DB migrations generated for both SQLite and PostgreSQL
- [ ] Manual: create agent → create version → activate → create session → verify system prompt from active version
- [ ] Manual: create eval cases → start eval run → verify results with scores
- [ ] Manual: navigate dashboard agent detail → versions/knowledge/evals tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)