### PR TITLE
fix: version activation 500 and eval run empty response

### DIFF
--- a/packages/server/src/db/drizzle-db.ts
+++ b/packages/server/src/db/drizzle-db.ts
@@ -1139,20 +1139,37 @@ export class DrizzleDb implements Db {
 
   async activateAgentVersion(id: string, agentName: string, tenantId: string = 'default'): Promise<void> {
     const { agentVersions, agents } = this.schema;
-    await this.drizzle.transaction(async (tx: any) => {
-      // Deactivate all versions for this agent
-      await tx.update(agentVersions)
-        .set({ isActive: 0, updatedAt: new Date().toISOString() })
-        .where(and(eq(agentVersions.tenantId, tenantId), eq(agentVersions.agentName, agentName)));
-      // Activate the target version
-      await tx.update(agentVersions)
-        .set({ isActive: 1, updatedAt: new Date().toISOString() })
-        .where(eq(agentVersions.id, id));
-      // Update agents table
-      await tx.update(agents)
-        .set({ activeVersionId: id, updatedAt: new Date().toISOString() })
-        .where(and(eq(agents.tenantId, tenantId), eq(agents.name, agentName)));
-    });
+    const now = new Date().toISOString();
+
+    if (this.dialect === 'pg') {
+      await this.drizzle.transaction(async (tx: any) => {
+        await tx.update(agentVersions)
+          .set({ isActive: 0, updatedAt: now })
+          .where(and(eq(agentVersions.tenantId, tenantId), eq(agentVersions.agentName, agentName)));
+        await tx.update(agentVersions)
+          .set({ isActive: 1, updatedAt: now })
+          .where(eq(agentVersions.id, id));
+        await tx.update(agents)
+          .set({ activeVersionId: id, updatedAt: now })
+          .where(and(eq(agents.tenantId, tenantId), eq(agents.name, agentName)));
+      });
+    } else {
+      // SQLite: better-sqlite3 transactions are synchronous
+      this.drizzle.transaction((tx: any) => {
+        tx.update(agentVersions)
+          .set({ isActive: 0, updatedAt: now })
+          .where(and(eq(agentVersions.tenantId, tenantId), eq(agentVersions.agentName, agentName)))
+          .run();
+        tx.update(agentVersions)
+          .set({ isActive: 1, updatedAt: now })
+          .where(eq(agentVersions.id, id))
+          .run();
+        tx.update(agents)
+          .set({ activeVersionId: id, updatedAt: now })
+          .where(and(eq(agents.tenantId, tenantId), eq(agents.name, agentName)))
+          .run();
+      });
+    }
   }
 
   async getNextVersionNumber(agentName: string, tenantId: string = 'default'): Promise<number> {

--- a/packages/server/src/routes/evals.ts
+++ b/packages/server/src/routes/evals.ts
@@ -206,7 +206,7 @@ export function evalRoutes(
       response: {
         201: {
           type: 'object',
-          properties: { case: { type: 'object' } },
+          properties: { case: { type: 'object', additionalProperties: true } },
           required: ['case'],
         },
         404: { $ref: 'ApiError#' },
@@ -251,7 +251,7 @@ export function evalRoutes(
       response: {
         200: {
           type: 'object',
-          properties: { case: { type: 'object' } },
+          properties: { case: { type: 'object', additionalProperties: true } },
           required: ['case'],
         },
         404: { $ref: 'ApiError#' },
@@ -283,7 +283,7 @@ export function evalRoutes(
       response: {
         200: {
           type: 'object',
-          properties: { case: { type: 'object' } },
+          properties: { case: { type: 'object', additionalProperties: true } },
           required: ['case'],
         },
         404: { $ref: 'ApiError#' },
@@ -365,9 +365,10 @@ export function evalRoutes(
           properties: {
             comparison: {
               type: 'object',
+              additionalProperties: true,
               properties: {
-                runA: { type: 'object' },
-                runB: { type: 'object' },
+                runA: { type: 'object', additionalProperties: true },
+                runB: { type: 'object', additionalProperties: true },
                 results: { type: 'array' },
               },
               required: ['runA', 'runB', 'results'],
@@ -449,7 +450,7 @@ export function evalRoutes(
       response: {
         201: {
           type: 'object',
-          properties: { run: { type: 'object' } },
+          properties: { run: { type: 'object', additionalProperties: true } },
           required: ['run'],
         },
         404: { $ref: 'ApiError#' },
@@ -551,7 +552,7 @@ export function evalRoutes(
       response: {
         200: {
           type: 'object',
-          properties: { run: { type: 'object' } },
+          properties: { run: { type: 'object', additionalProperties: true } },
           required: ['run'],
         },
         404: { $ref: 'ApiError#' },
@@ -619,7 +620,7 @@ export function evalRoutes(
       response: {
         200: {
           type: 'object',
-          properties: { result: { type: 'object' } },
+          properties: { result: { type: 'object', additionalProperties: true } },
           required: ['result'],
         },
         404: { $ref: 'ApiError#' },


### PR DESCRIPTION
## Summary

Follow-up to #92, addresses remaining bugs from #91 comment.

**1. Version activation returns 500: "Transaction function cannot return a promise"**

SQLite's `better-sqlite3` driver requires synchronous transaction callbacks. The `activateAgentVersion` method used `async/await` inside `this.drizzle.transaction()`, which broke on SQLite. Now branches on dialect — synchronous `.run()` for SQLite, async `await` for PG.

**2. Eval run/case/result endpoints return empty `{}`**

Fastify's `fast-json-stringify` strips properties not declared in the response schema. All eval response schemas used `{ type: 'object' }` without `additionalProperties: true`, causing the serializer to output `{}`. Fixed across all eval case, run, result, and comparison response schemas.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (257/257)
- [ ] Manual: `POST /agents/bob/versions/{id}/activate` → 200 (was 500)
- [ ] Manual: `POST /agents/bob/eval-runs` → returns full run object (was `{}`)
- [ ] Manual: `GET /agents/bob/eval-cases` → returns full case objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)