### PR TITLE
fix: add missing API endpoints and accept UUID in cloneFrom

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -720,6 +720,11 @@ export class AshClient {
     return res.result;
   }
 
+  /** Score results within an eval run. Pass resultId to score a single result, or omit to score all. */
+  async scoreEvalRun(agentName: string, runId: string, opts: { resultId?: string; humanScore?: number; humanNotes?: string }): Promise<{ scored: number; results: EvalResult[] }> {
+    return this.request<{ scored: number; results: EvalResult[] }>('POST', `/api/agents/${encodeURIComponent(agentName)}/eval-runs/${runId}/score`, opts);
+  }
+
   // -- Agent Config -------------------------------------------------------------
 
   async getAgentConfig(agentName: string): Promise<Record<string, unknown>> {
@@ -727,8 +732,10 @@ export class AshClient {
     return res.config;
   }
 
-  async updateAgentConfig(agentName: string, config: Record<string, unknown>): Promise<Agent> {
-    return this.updateAgent(agentName, { config });
+  /** Update agent config via dedicated PATCH /api/agents/:name/config endpoint */
+  async updateAgentConfig(agentName: string, config: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const res = await this.request<{ config: Record<string, unknown> }>('PATCH', `/api/agents/${encodeURIComponent(agentName)}/config`, config);
+    return res.config;
   }
 
   // -- Analytics ----------------------------------------------------------------

--- a/packages/server/src/__tests__/openapi.test.ts
+++ b/packages/server/src/__tests__/openapi.test.ts
@@ -82,7 +82,7 @@ describe('OpenAPI spec generation', () => {
         if (path[method]) count++;
       }
     }
-    expect(count).toBe(29);
+    expect(count).toBe(30);
   });
 
   it('has component schemas for Agent, Session, ApiError, HealthResponse', () => {

--- a/packages/server/src/routes/agent-versions.ts
+++ b/packages/server/src/routes/agent-versions.ts
@@ -111,7 +111,7 @@ export function agentVersionRoutes(app: FastifyInstance): void {
             type: 'array',
             items: { type: 'string' },
           },
-          cloneFrom: { type: 'integer', minimum: 1 },
+          cloneFrom: { type: ['integer', 'string'], description: 'Version number (integer) or version UUID to clone from' },
         },
       },
       response: {
@@ -135,15 +135,16 @@ export function agentVersionRoutes(app: FastifyInstance): void {
       systemPrompt?: string;
       releaseNotes?: string;
       knowledgeFiles?: string[];
-      cloneFrom?: number;
+      cloneFrom?: number | string;
     } | undefined;
 
     let systemPrompt = body?.systemPrompt ?? null;
     let knowledgeFiles = body?.knowledgeFiles ?? null;
 
     // If cloneFrom is specified, copy systemPrompt and knowledgeFiles from that version
+    // Accepts both version number (integer) and version UUID (string)
     if (body?.cloneFrom != null) {
-      const sourceVersion = await getAgentVersionByNumber(req.params.name, body.cloneFrom, req.tenantId);
+      const sourceVersion = await resolveVersion(req.params.name, String(body.cloneFrom), req.tenantId);
       if (!sourceVersion) {
         return reply.status(400).send({ error: `Source version ${body.cloneFrom} not found`, statusCode: 400 });
       }

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -287,6 +287,46 @@ export function agentRoutes(app: FastifyInstance, dataDir: string, pool?: Sandbo
     return reply.send({ agent: redactAgent(agent) });
   });
 
+  // Update agent config (dedicated endpoint)
+  app.patch<{ Params: { name: string } }>('/api/agents/:name/config', {
+    schema: {
+      tags: ['agents'],
+      params: nameParam,
+      body: {
+        type: 'object',
+        description: 'Agent configuration fields to merge with existing config',
+        additionalProperties: true,
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            config: { type: 'object', additionalProperties: true },
+          },
+          required: ['config'],
+        },
+        404: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const existing = await getAgent(req.params.name, req.tenantId);
+    if (!existing) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const config = req.body as Record<string, unknown> | undefined;
+    if (!config || Object.keys(config).length === 0) {
+      return reply.send({ config: existing.config ?? {} });
+    }
+
+    const mergedConfig = { ...(existing.config ?? {}), ...config };
+    const agent = await updateAgent(req.params.name, { config: mergedConfig }, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+    return reply.send({ config: agent.config ?? {} });
+  });
+
   // Get agent config
   app.get<{ Params: { name: string } }>('/api/agents/:name/config', {
     schema: {

--- a/packages/server/src/routes/evals.ts
+++ b/packages/server/src/routes/evals.ts
@@ -605,6 +605,72 @@ export function evalRoutes(
 
   // ── Human Scoring ─────────────────────────────────────────────────────
 
+  // Score results within an eval run (convenience endpoint)
+  app.post<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-runs/:id/score', {
+    schema: {
+      tags: ['evals'],
+      params: nameAndIdParams,
+      body: {
+        type: 'object',
+        properties: {
+          resultId: { type: 'string', format: 'uuid', description: 'Specific result to score. If omitted, scores are applied to all results.' },
+          humanScore: { type: 'number', minimum: 1, maximum: 5 },
+          humanNotes: { type: 'string', maxLength: 10_000 },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            scored: { type: 'integer' },
+            results: { type: 'array' },
+          },
+          required: ['scored'],
+        },
+        404: { $ref: 'ApiError#' },
+        400: { $ref: 'ApiError#' },
+      },
+    },
+  }, async (req, reply) => {
+    const agent = await getAgent(req.params.name, req.tenantId);
+    if (!agent) {
+      return reply.status(404).send({ error: 'Agent not found', statusCode: 404 });
+    }
+
+    const run = await getEvalRun(req.params.id);
+    if (!run || run.agentName !== agent.name) {
+      return reply.status(404).send({ error: 'Eval run not found', statusCode: 404 });
+    }
+
+    const body = req.body as { resultId?: string; humanScore?: number; humanNotes?: string } | undefined;
+    if (!body || (body.humanScore === undefined && body.humanNotes === undefined)) {
+      return reply.status(400).send({ error: 'Provide humanScore and/or humanNotes', statusCode: 400 });
+    }
+
+    const updates: { humanScore?: number; humanNotes?: string } = {};
+    if (body.humanScore !== undefined) updates.humanScore = body.humanScore;
+    if (body.humanNotes !== undefined) updates.humanNotes = body.humanNotes;
+
+    if (body.resultId) {
+      // Score a specific result
+      const existing = await getEvalResult(body.resultId);
+      if (!existing || existing.evalRunId !== run.id) {
+        return reply.status(404).send({ error: 'Eval result not found in this run', statusCode: 404 });
+      }
+      await updateEvalResult(body.resultId, updates);
+      const updated = await getEvalResult(body.resultId);
+      return reply.send({ scored: 1, results: [updated] });
+    }
+
+    // Score all results in the run
+    const results = await listEvalResults(run.id);
+    for (const r of results) {
+      await updateEvalResult(r.id, updates);
+    }
+    const updatedResults = await listEvalResults(run.id);
+    return reply.send({ scored: results.length, results: updatedResults });
+  });
+
   // Update eval result with human score/notes
   app.patch<{ Params: { name: string; id: string } }>('/api/agents/:name/eval-results/:id', {
     schema: {


### PR DESCRIPTION
## Summary
- Adds dedicated `PATCH /api/agents/:name/config` endpoint (previously config could only be updated via `PATCH /api/agents/:name` with config in body)
- Adds `POST /api/agents/:name/eval-runs/:id/score` endpoint for human scoring of eval results (accepts optional `resultId` to score a single result, or scores all results in the run)
- Makes `cloneFrom` in version creation accept both integer version numbers and UUID strings (reuses the existing `resolveVersion` helper)
- Updates SDK client: new `scoreEvalRun` method, `updateAgentConfig` now uses dedicated PATCH endpoint

Closes remaining gaps from #91.

## Test plan
- [x] All 257 tests pass
- [x] Server and SDK build successfully
- [ ] Manual: `PATCH /api/agents/bob/config` with `{"model":"sonnet"}` returns updated config
- [ ] Manual: `POST /api/agents/bob/eval-runs/{id}/score` with `{"humanScore":4}` scores results
- [ ] Manual: `POST /api/agents/bob/versions` with `{"cloneFrom":"<uuid>"}` clones from that version

🤖 Generated with [Claude Code](https://claude.com/claude-code)