### PR TITLE
feat: add agent config page and management links to dashboard

### DIFF
--- a/packages/dashboard/app/agents/config/page.tsx
+++ b/packages/dashboard/app/agents/config/page.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { getClient } from '@/lib/client'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ShimmerBlock } from '@/components/ui/shimmer'
+import {
+  ArrowLeft,
+  Save,
+  Loader2,
+  RotateCcw,
+} from 'lucide-react'
+
+const CONFIG_FIELDS = [
+  { key: 'description', label: 'Description', type: 'text' as const, placeholder: 'A brief description of this agent' },
+  { key: 'model', label: 'Model', type: 'text' as const, placeholder: 'e.g. claude-sonnet-4-5-20250514' },
+  { key: 'systemPrompt', label: 'System Prompt', type: 'textarea' as const, placeholder: 'System prompt for the agent...' },
+  { key: 'max_turns', label: 'Max Turns', type: 'number' as const, placeholder: 'e.g. 10' },
+  { key: 'permission_mode', label: 'Permission Mode', type: 'select' as const, options: ['default', 'plan', 'bypassPermissions'] },
+] as const
+
+function ConfigContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get('name')
+  const [config, setConfig] = useState<Record<string, unknown>>({})
+  const [original, setOriginal] = useState<Record<string, unknown>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    if (!name) {
+      setLoading(false)
+      return
+    }
+    async function fetchConfig() {
+      try {
+        const data = await getClient().getAgentConfig(name!)
+        setConfig(data)
+        setOriginal(data)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to fetch config')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchConfig()
+  }, [name])
+
+  async function handleSave() {
+    if (!name) return
+    setSaving(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      // Only send changed fields
+      const changes: Record<string, unknown> = {}
+      for (const field of CONFIG_FIELDS) {
+        const val = config[field.key]
+        if (val !== original[field.key]) {
+          changes[field.key] = val
+        }
+      }
+      if (Object.keys(changes).length === 0) {
+        setSuccess(true)
+        return
+      }
+      const updated = await getClient().updateAgentConfig(name, changes)
+      setConfig(updated)
+      setOriginal(updated)
+      setSuccess(true)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save config')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleReset() {
+    setConfig({ ...original })
+    setError(null)
+    setSuccess(false)
+  }
+
+  function updateField(key: string, value: unknown) {
+    setConfig((prev) => ({ ...prev, [key]: value }))
+    setSuccess(false)
+  }
+
+  const hasChanges = JSON.stringify(config) !== JSON.stringify(original)
+
+  if (!name) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-white/50">No agent name specified.</p>
+        <Link href="/agents" className="text-indigo-400 hover:text-indigo-300 text-sm mt-2 inline-block">
+          Back to agents
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href={`/agents/detail?name=${encodeURIComponent(name)}`}
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to {name}
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Configuration</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Edit config for <span className="text-white/70">{name}</span>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasChanges && (
+            <Button variant="ghost" onClick={handleReset}>
+              <RotateCcw className="h-4 w-4 mr-2" />
+              Reset
+            </Button>
+          )}
+          <Button onClick={handleSave} disabled={saving || !hasChanges}>
+            {saving ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-2" />
+            )}
+            Save
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="text-sm text-green-400 bg-green-500/10 border border-green-500/20 rounded-lg px-4 py-2">
+          Configuration saved successfully.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3, 4].map((i) => (
+            <ShimmerBlock key={i} height={60} />
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardContent>
+            <div className="space-y-5">
+              {CONFIG_FIELDS.map((field) => {
+                const value = config[field.key] ?? ''
+
+                if (field.type === 'textarea') {
+                  return (
+                    <div key={field.key} className="space-y-1.5">
+                      <label className="block text-sm font-medium text-white/70">
+                        {field.label}
+                      </label>
+                      <textarea
+                        value={String(value)}
+                        onChange={(e) => updateField(field.key, e.target.value || undefined)}
+                        rows={5}
+                        placeholder={field.placeholder}
+                        className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50 resize-none"
+                      />
+                    </div>
+                  )
+                }
+
+                if (field.type === 'select') {
+                  return (
+                    <div key={field.key} className="space-y-1.5">
+                      <label className="block text-sm font-medium text-white/70">
+                        {field.label}
+                      </label>
+                      <select
+                        value={String(value)}
+                        onChange={(e) => updateField(field.key, e.target.value || undefined)}
+                        className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white focus-visible:outline-none focus-visible:border-indigo-500/50"
+                      >
+                        <option value="" className="bg-[#1c2129]">Not set</option>
+                        {field.options.map((opt) => (
+                          <option key={opt} value={opt} className="bg-[#1c2129]">
+                            {opt}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )
+                }
+
+                if (field.type === 'number') {
+                  return (
+                    <div key={field.key} className="space-y-1.5">
+                      <label className="block text-sm font-medium text-white/70">
+                        {field.label}
+                      </label>
+                      <input
+                        type="number"
+                        value={value === undefined || value === '' ? '' : Number(value)}
+                        onChange={(e) => updateField(field.key, e.target.value ? Number(e.target.value) : undefined)}
+                        placeholder={field.placeholder}
+                        className="flex w-full rounded-xl border px-3 py-2 text-sm bg-white/5 border-white/10 text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:border-indigo-500/50"
+                      />
+                    </div>
+                  )
+                }
+
+                return (
+                  <Input
+                    key={field.key}
+                    label={field.label}
+                    value={String(value)}
+                    onChange={(e) => updateField(field.key, e.target.value || undefined)}
+                    placeholder={field.placeholder}
+                  />
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default function ConfigPage() {
+  return (
+    <Suspense fallback={<ShimmerBlock height={200} />}>
+      <ConfigContent />
+    </Suspense>
+  )
+}

--- a/packages/dashboard/app/agents/detail/page.tsx
+++ b/packages/dashboard/app/agents/detail/page.tsx
@@ -16,6 +16,7 @@ import {
   FlaskConical,
   FolderOpen,
   Clock,
+  Settings,
 } from 'lucide-react'
 import type { Agent } from '@ash-ai/shared'
 
@@ -86,6 +87,12 @@ function AgentDetailContent() {
 
   const tabs = [
     {
+      label: 'Config',
+      href: `/agents/config?name=${encodeURIComponent(agent.name)}`,
+      icon: Settings,
+      description: 'View and edit agent configuration',
+    },
+    {
       label: 'Versions',
       href: `/agents/versions?name=${encodeURIComponent(agent.name)}`,
       icon: GitBranch,
@@ -154,7 +161,7 @@ function AgentDetailContent() {
       </Card>
 
       {/* Tab cards */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {tabs.map((tab) => (
           <Link key={tab.label} href={tab.href}>
             <Card className="hover:border-white/20 hover:bg-white/[0.02] transition-all cursor-pointer h-full">

--- a/packages/dashboard/app/agents/page.tsx
+++ b/packages/dashboard/app/agents/page.tsx
@@ -12,10 +12,14 @@ import { ShimmerBlock } from '@/components/ui/shimmer'
 import { formatRelativeTime } from '@/lib/utils'
 import {
   Bot,
+  BookOpen,
   Code2,
   Copy,
+  FlaskConical,
+  GitBranch,
   MoreVertical,
   Plus,
+  Settings,
   Terminal,
   Trash2,
   Upload,
@@ -168,7 +172,36 @@ function AgentCard({
             {showMenu && (
               <>
                 <div className="fixed inset-0" onClick={() => setShowMenu(false)} />
-                <div className="absolute right-0 mt-1 w-40 rounded-lg border border-white/10 bg-[#1c2129] shadow-xl z-10 py-1">
+                <div className="absolute right-0 mt-1 w-44 rounded-lg border border-white/10 bg-[#1c2129] shadow-xl z-10 py-1">
+                  <Link
+                    href={`/agents/config?name=${encodeURIComponent(agent.name)}`}
+                    onClick={() => setShowMenu(false)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    <Settings className="h-3.5 w-3.5" /> Config
+                  </Link>
+                  <Link
+                    href={`/agents/versions?name=${encodeURIComponent(agent.name)}`}
+                    onClick={() => setShowMenu(false)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    <GitBranch className="h-3.5 w-3.5" /> Versions
+                  </Link>
+                  <Link
+                    href={`/agents/knowledge?name=${encodeURIComponent(agent.name)}`}
+                    onClick={() => setShowMenu(false)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    <BookOpen className="h-3.5 w-3.5" /> Knowledge
+                  </Link>
+                  <Link
+                    href={`/agents/evals?name=${encodeURIComponent(agent.name)}`}
+                    onClick={() => setShowMenu(false)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    <FlaskConical className="h-3.5 w-3.5" /> Evals
+                  </Link>
+                  <div className="my-1 border-t border-white/5" />
                   <button
                     onClick={() => {
                       navigator.clipboard.writeText(agent.name)


### PR DESCRIPTION
## Summary
- Adds `/agents/config` page for viewing and editing agent configuration (description, model, system prompt, max_turns, permission_mode) via `GET/PATCH /api/agents/:name/config`
- Adds Config tab to the agent detail page (now 4 tabs: Config, Versions, Knowledge, Evals)
- Adds management links (Config, Versions, Knowledge, Evals) to the three-dot menu on agent cards in the agents list page

Closes #96.

## Test plan
- [x] Dashboard builds successfully (`pnpm build`)
- [x] All 257 server tests pass
- [ ] Manual: Navigate to agents list, click agent name → detail page shows 4 tab cards
- [ ] Manual: Click Config tab → config page loads with current values, edit and save works
- [ ] Manual: Three-dot menu on agent card shows Config, Versions, Knowledge, Evals links
- [ ] Manual: Each menu link navigates to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)