### PR TITLE
feat: MCP connection visibility, tool call tracing, session diagnostics

### DIFF
--- a/.changeset/mcp-debugging-visibility.md
+++ b/.changeset/mcp-debugging-visibility.md
@@ -1,0 +1,13 @@
+---
+"@ash-ai/shared": minor
+"@ash-ai/sandbox": minor
+"@ash-ai/server": minor
+"@ash-ai/dashboard": minor
+---
+
+Add MCP connection visibility, tool call tracing, and session diagnostics.
+
+- `@ash-ai/shared` — Add `mcp_status` session event type; add `mcpServers` to `SessionConfig` so MCP configuration is persisted on the session record
+- `@ash-ai/server` — Store `mcpServers` in session config at creation (exposed via `GET /api/sessions/:id`); emit `mcp_status` events when MCP servers are configured; propagate bridge stderr MCP errors as `mcp_status` error events
+- `@ash-ai/sandbox` — Add `onStderrError` callback to `CreateSandboxOpts` that fires on MCP-related stderr patterns (connection refused, DisallowedHost, etc.)
+- `@ash-ai/dashboard` — Add MCP status badge to session detail header showing server count or error state; add `mcp_status` event color (cyan) to events timeline; improve event summaries for MCP events

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -21,6 +21,7 @@ import {
   MessageSquare,
   Pause,
   Play,
+  Plug,
   Square,
   Terminal,
 } from 'lucide-react'
@@ -244,6 +245,7 @@ function SessionDetail({ session }: { session: Session }) {
               {formatRelativeTime(session.createdAt)}
             </span>
             {session.model && <Badge variant="info">{session.model}</Badge>}
+            <McpStatusBadge events={events} config={session.config} />
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -478,6 +480,7 @@ function EventsTab({ events }: { events: SessionEvent[] }) {
     error: 'text-red-400',
     turn_complete: 'text-green-400',
     lifecycle: 'text-zinc-400',
+    mcp_status: 'text-cyan-400',
   }
 
   return (
@@ -505,7 +508,11 @@ function EventRow({
       typeof event.data === 'string' ? JSON.parse(event.data) : event.data
     if (data && typeof data === 'object') {
       const d = data as Record<string, unknown>
-      if (typeof d.text === 'string') summary = d.text.slice(0, 100)
+      if (typeof d.action === 'string' && d.action === 'configured' && Array.isArray(d.servers)) {
+        summary = `${d.servers.length} server(s): ${(d.servers as Array<{name?: string}>).map(s => s.name).join(', ')}`
+      } else if (typeof d.action === 'string' && d.action === 'error' && typeof d.error === 'string') {
+        summary = `MCP error: ${d.error.slice(0, 80)}`
+      } else if (typeof d.text === 'string') summary = d.text.slice(0, 100)
       else if (typeof d.name === 'string') summary = d.name
       else if (typeof d.error === 'string') summary = d.error.slice(0, 100)
     }
@@ -536,6 +543,49 @@ function EventRow({
         </div>
       )}
     </div>
+  )
+}
+
+// ─── MCP Status Badge ───
+
+function McpStatusBadge({ events, config }: { events: SessionEvent[]; config?: { mcpServers?: Record<string, unknown> } | null }) {
+  const mcpEvents = events.filter(e => e.type === 'mcp_status')
+  const mcpServers = config?.mcpServers
+
+  // No MCP configured at all
+  if (!mcpServers && mcpEvents.length === 0) return null
+
+  const hasError = mcpEvents.some(e => {
+    try {
+      const d = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
+      return d?.action === 'error'
+    } catch { return false }
+  })
+
+  const serverCount = mcpServers ? Object.keys(mcpServers).length : 0
+  const configuredEvent = mcpEvents.find(e => {
+    try {
+      const d = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
+      return d?.action === 'configured'
+    } catch { return false }
+  })
+  const configuredCount = configuredEvent ? (() => {
+    try {
+      const d = typeof configuredEvent.data === 'string' ? JSON.parse(configuredEvent.data) : configuredEvent.data
+      return d?.servers?.length ?? 0
+    } catch { return 0 }
+  })() : serverCount
+
+  return (
+    <span className={cn(
+      'inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium',
+      hasError
+        ? 'bg-red-500/10 text-red-400 border border-red-500/20'
+        : 'bg-cyan-500/10 text-cyan-400 border border-cyan-500/20'
+    )}>
+      <Plug className="h-3 w-3" />
+      {hasError ? `MCP Error` : `MCP: ${configuredCount} server${configuredCount !== 1 ? 's' : ''}`}
+    </span>
   )
 }
 

--- a/packages/sandbox/src/manager.ts
+++ b/packages/sandbox/src/manager.ts
@@ -35,6 +35,8 @@ export interface CreateSandboxOpts {
   skipAgentCopy?: boolean;
   limits?: Partial<SandboxLimits>;
   onOomKill?: (sandboxId: string) => void;
+  /** Called when bridge stderr contains significant errors (e.g. MCP connection failures). */
+  onStderrError?: (sandboxId: string, text: string) => void;
   /** Extra env vars to inject into the sandbox (e.g. decrypted credentials). */
   extraEnv?: Record<string, string>;
   /** Per-session MCP servers. Merged into the agent's .mcp.json (session overrides agent). */
@@ -277,6 +279,11 @@ export class SandboxManager {
       const text = chunk.toString().trimEnd();
       console.error(`[sandbox:${shortId}:err] ${text}`);
       this.appendLog(id, 'stderr', text);
+      // Surface significant errors (MCP failures, connection errors) to the caller
+      const lc = text.toLowerCase();
+      if (lc.includes('mcp') || lc.includes('econnrefused') || lc.includes('connection refused') || lc.includes('disallowedhost') || lc.includes('failed to connect')) {
+        opts.onStderrError?.(id, text);
+      }
     });
 
     // OOM detection

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -225,6 +225,9 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
             console.error(`Failed to update session status on OOM: ${err}`)
           );
         },
+        onStderrError: (_sandboxId: string, text: string) => {
+          insertSessionEvent(sessionId, 'mcp_status', JSON.stringify({ action: 'error', error: text }), req.tenantId).catch((err) => console.error(`Failed to persist mcp_status error event: ${err}`));
+        },
       });
       span.addEvent('createSandbox.end');
 
@@ -233,8 +236,8 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
       if (effectiveModel) span.setAttribute('ash.model', effectiveModel);
 
       // Build session-level SDK config (persisted on session, injected into every query)
-      const sessionConfig: SessionConfig | null = (allowedTools || disallowedTools || betas || subagents || initialAgent)
-        ? { allowedTools, disallowedTools, betas, subagents, initialAgent }
+      const sessionConfig: SessionConfig | null = (allowedTools || disallowedTools || betas || subagents || initialAgent || mcpServers)
+        ? { allowedTools, disallowedTools, betas, subagents, initialAgent, mcpServers }
         : null;
 
       const session = await insertSession(sessionId, agentRecord.name, handle.sandboxId, req.tenantId, undefined, effectiveModel, sessionConfig);
@@ -245,6 +248,17 @@ export function sessionRoutes(app: FastifyInstance, coordinator: RunnerCoordinat
       // Record lifecycle event
       insertSessionEvent(sessionId, 'lifecycle', JSON.stringify({ action: 'created', agentName: agentRecord.name, model: effectiveModel }), req.tenantId).catch((err) => console.error(`Failed to persist lifecycle event: ${err}`));
       telemetry.emit({ sessionId, agentName: agentRecord.name, type: 'lifecycle', data: { status: 'active', action: 'created' } });
+
+      // Record MCP configuration event so dashboard shows which MCP servers were configured
+      if (mcpServers && Object.keys(mcpServers).length > 0) {
+        const mcpSummary = Object.entries(mcpServers).map(([name, cfg]) => ({
+          name,
+          transport: cfg.url ? 'sse' : 'stdio',
+          ...(cfg.url && { url: cfg.url }),
+          ...(cfg.command && { command: cfg.command }),
+        }));
+        insertSessionEvent(sessionId, 'mcp_status', JSON.stringify({ action: 'configured', servers: mcpSummary }), req.tenantId).catch((err) => console.error(`Failed to persist mcp_status event: ${err}`));
+      }
 
       return reply.status(201).send({ session: { ...session, status: 'active', runnerId: effectiveRunnerId } });
     } catch (err: unknown) {

--- a/packages/server/src/runner/local-backend.ts
+++ b/packages/server/src/runner/local-backend.ts
@@ -22,6 +22,7 @@ export class LocalRunnerBackend implements RunnerBackend {
       skipAgentCopy: opts.skipAgentCopy,
       limits: opts.limits,
       onOomKill: opts.onOomKill,
+      onStderrError: opts.onStderrError,
       extraEnv: opts.extraEnv,
       mcpServers: opts.mcpServers,
       systemPrompt: opts.systemPrompt,

--- a/packages/server/src/runner/types.ts
+++ b/packages/server/src/runner/types.ts
@@ -9,6 +9,8 @@ export interface CreateSandboxRequest {
   skipAgentCopy?: boolean;
   limits?: Partial<SandboxLimits>;
   onOomKill?: (sandboxId: string) => void;
+  /** Called when bridge stderr contains significant errors (e.g. MCP connection failures). */
+  onStderrError?: (sandboxId: string, text: string) => void;
   /** Extra env vars to inject into the sandbox (e.g. decrypted credentials). */
   extraEnv?: Record<string, string>;
   /** Per-session MCP servers. Merged into agent's .mcp.json (session overrides agent). */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -212,7 +212,8 @@ export type SessionEventType =
   | 'reasoning'      // Extended thinking / chain-of-thought
   | 'error'          // Error during execution
   | 'turn_complete'  // Agent turn finished (result message)
-  | 'lifecycle';     // Session state change (created, paused, resumed, ended)
+  | 'lifecycle'      // Session state change (created, paused, resumed, ended)
+  | 'mcp_status';    // MCP server connection status (configured, connected, error)
 
 export interface SessionEvent {
   id: string;
@@ -761,6 +762,7 @@ export interface SessionConfig {
   betas?: string[];
   subagents?: Record<string, unknown>;
   initialAgent?: string;
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 /** Request body for PATCH /api/sessions/:id/config — update session config mid-session. */


### PR DESCRIPTION
## Summary

MCP connection failures are currently silent — when an MCP server is unreachable or misconfigured, there's no indication in session events, logs, or the dashboard. This PR adds visibility across the stack.

- **New `mcp_status` session event type** — tracks MCP server configuration and errors in the session timeline
- **`mcpServers` persisted in `SessionConfig`** — `GET /api/sessions/:id` now exposes which MCP servers were configured for a session
- **MCP error propagation from sandbox stderr** — bridge stderr patterns matching MCP failures (`ECONNREFUSED`, `DisallowedHost`, `failed to connect`, etc.) are surfaced as `mcp_status` error events via a new `onStderrError` callback
- **Dashboard MCP status badge** — session detail header shows a cyan "MCP: N servers" badge or a red "MCP Error" badge based on events
- **Improved event timeline** — `mcp_status` events render with cyan color and show server names or error messages in the summary

## What this looks like

When a session is created with `mcpServers`:
1. A `mcp_status` event is recorded: `{ action: "configured", servers: [{ name: "cai_data", transport: "sse", url: "..." }] }`
2. If bridge stderr contains MCP-related errors, additional `mcp_status` events are recorded: `{ action: "error", error: "..." }`
3. Dashboard shows the MCP badge in the session header and events in the timeline

Closes #99

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (257 tests)
- [ ] Create a session with `mcpServers` → verify `mcp_status` event appears in events timeline
- [ ] Create a session with unreachable MCP server → verify error event surfaces in dashboard
- [ ] Verify `GET /api/sessions/:id` returns `config.mcpServers`
- [ ] Verify dashboard shows MCP status badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)